### PR TITLE
Develop

### DIFF
--- a/esl_quicksort.c
+++ b/esl_quicksort.c
@@ -137,7 +137,7 @@ utest_floatsort(ESL_RANDOMNESS *rng, int N, int K)
 {
   char   msg[]     = "esl_quicksort: float sort test failed";
   float *x         = malloc(sizeof(float) * N);
-  int   *sorted_at = malloc(sizeof(int)   * K);
+  int   *sorted_at = malloc(sizeof(int)   * N);
   int    i,r;
 
   for (i = 0; i < N; i++)

--- a/miniapps/esl-alistat.c
+++ b/miniapps/esl-alistat.c
@@ -260,7 +260,7 @@ main(int argc, char **argv)
 	{
 	  printf("%-6d %-20s %10s %7d %7" PRId64 " %12" PRId64, 
 		 nali, 
-		 msa->name,
+		 msa->name != NULL ? msa->name : "(null)",
 		 esl_msafile_DecodeFormat(fmt),
 		 nseq,
 		 alen,


### PR DESCRIPTION
- fixed incorrect array size in utest_floatsort
- add NULL check for printf() argument
