### PR TITLE
Fixes bug in esl_sqio_ascii.c::loadbuf() related to ESL_SQASCII->is_recording

### DIFF
--- a/esl_sqio_ascii.c
+++ b/esl_sqio_ascii.c
@@ -2148,7 +2148,7 @@ loadbuf(ESL_SQFILE *sqfp)
       ascii->balloc = 0;
       ascii->bpos   = 0;
       ascii->nc     = ascii->mn - ascii->mpos;
-      ascii->mpos  += ascii->mn;
+      ascii->mpos  += ascii->nc;
   }
   else
   { /* Copy next line from <mem> into <buf>. Might require new load(s) into <mem>. */


### PR DESCRIPTION
Ioanna Kalvari of Rfam reported a esl-seqstat seg fault to me on the attached file (orig-fail.fa.txt). The seg fault goes away if --rna or --dna is used. The bug was in esl_sqio_ascii.c::sqfile_GuessAlphabet(), and was a fun one to track down. The bug only causes a problem if the ESL_SQASCII object has 'is_recording' on and 'is_linebased' off, which only occurs in one place in all of Easel/HMMER/Infernal as far as I can tell, in sqfile_GuessAlphabet(). 

Further, the bug only shows itself if the input file is a single sequence, and in a file of more than 4096 bytes and less than 4000 nucleotides/residues. I've also attached fail.fa.txt and pass.fa.txt which differ by a single nucleotide, but fail.fa.txt causes the seg fault and pass.fa.txt does not. 

The problem occurs when a second memory/buffer load is necessary when 'is_recording' is on. That is only necessary if the first memory load of 4096 bytes (eslREADBUFSIZE) does not include the entire first (and only) sequence and that sequence is less than 4000 nucleotides. That is somewhat rare because it will only happen if there's >= 96 non-nucleotide characters in the sequence file (e.g. long name and description), and the file meets the special size/length requirements. 

I *think* the one line fix I'm proposing is the correct one. I've convinced myself that it makes sense: the position of the next buffer to load ('mpos') should not be incremented by 'mn' (number of characters in 'mem') but rather by 'nc' (number of characters in the buffer). 'mn' and 'nc' will be different if the previous fread() hit EOF.

Note that if 'is_recording' is off, the loadmem() call a few lines above the bug fix will have set 'mpos' to 0 and 'mn' to n (number characters read by fread()), so in loadbuf() with the bug fix 'nc' becomes n ('mn' - 'mpos'), and so the bug fix code change has no effect because 'mn' and 'nc' are equal to the same value (n). (This only makes sense if staring at both the loadmem() code and loadbuf() proposed bug fix, and even then it took me several minutes to write.) 

All that said, I feel a little light headed after tracing down this problem, so I wouldn't be too surprised if some of my reasoning isn't quite right. Please take a look at let me know what you think.

[orig-fail.fa.txt](https://github.com/EddyRivasLab/easel/files/900726/orig-fail.fa.txt)
[pass.fa.txt](https://github.com/EddyRivasLab/easel/files/900725/pass.fa.txt)
[fail.fa.txt](https://github.com/EddyRivasLab/easel/files/900724/fail.fa.txt)


