### PR TITLE
python3 is required for re.fullmatch();  make it explicit in shebang

### DIFF
--- a/devkit/rmanprocess.py
+++ b/devkit/rmanprocess.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python3
 
 # rmanprocess.py
 # Massages output of PolyGlotMan's `rman -f latex2e` to fit Tufteian userguide style.


### PR DESCRIPTION
On my machine, using rmanprocess.py (e.g. building HMMER userguide with 'make pdf') resulted in numerous errors of this form:
File "../../easel/devkit/rmanprocess.py", line 41, in <module>
    if not re.fullmatch(r'\s*', line):
AttributeError: 'module' object has no attribute 'fullmatch'

The cause of these errors is that re.fullmatch() only exists in python3, but rmanprocess.py's shebang line only called for 
   #! /usr/bin/env python 
If the default python install is 2.x,  the script fails with the errors above. 

Changing to 
   #! /usr/bin/env python3
forces the use of the correct version.

(This is not future-proof to the arrival of python4. I am unfamiliar with future-proof options to make it work, but I suspect that other things in the script might break in a change to 4.x, so it may be good to force 3.x)
