### PR TITLE
PPC fix, IEEE comparison check, isnanf check, travis test/badge

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,35 @@
+language: minimal
+
+services:
+  - docker
+
+env:
+  global:
+    - PATH=$HOME/bin:$PATH
+
+matrix:
+  include:
+    - env: TARGET=x86_64-pc-linux-gnu
+      name: x86_64-pc-linux-gnu
+    - env: TARGET=powerpc-unknown-linux-gnu
+      name: powerpc-unknown-linux-gnu
+    - os: osx
+      env: TARGET=x86_64-apple-darwin
+      name: x86_64-apple-darwin
+
+before_install:
+  - bash <(curl -fsSL https://raw.githubusercontent.com/horta/port-of-hmmer/master/ci/travis.sh)
+
+script:
+  - sandbox_run autoconf
+  - if [ "$TARGET" == powerpc-unknown-linux-gnu ]; then sandbox_run CFLAGS=-O0 ./configure; fi
+  - if [ "$TARGET" != powerpc-unknown-linux-gnu ]; then sandbox_run ./configure; fi
+  - sandbox_run make
+  - sandbox_run make check
+
+notifications:
+  email:
+    recipients:
+      - danilo.horta@pm.me
+    on_success: never
+    on_failure: always

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Easel - a library of C functions for biological sequence analysis
 
-[![Travis](https://img.shields.io/travis/com/horta/easel/eddy-develop.svg?label=linux%20%26%20macos%20builds)](https://travis-ci.com/horta/easel)
+[![Travis](https://img.shields.io/travis/com/horta/easel/ppc-fix.svg?label=linux%20%26%20macos%20builds)](https://travis-ci.com/horta/easel)
 
 [Easel](http://bioeasel.org) is an ANSI C code library developed by
 the [Eddy/Rivas laboratory](http://eddylab.org) at Harvard for

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Easel - a library of C functions for biological sequence analysis
 
+[![Travis](https://img.shields.io/travis/com/horta/easel/eddy-develop.svg?label=linux%20%26%20macos%20builds)](https://travis-ci.com/horta/easel)
+
 [Easel](http://bioeasel.org) is an ANSI C code library developed by
 the [Eddy/Rivas laboratory](http://eddylab.org) at Harvard for
 computational analysis of biological sequences using probabilistic

--- a/configure.ac
+++ b/configure.ac
@@ -1,5 +1,5 @@
 # process this file with autoconf to produce the Easel configuration script.
-# 
+#
 # reminders to save re-reading autoconf manual for the n'th time:
 #   output variables:
 #      - defined here as normal shell variables, e.g. FOO="my string"
@@ -64,6 +64,9 @@ m4_include([m4/esl_avx.m4])
 m4_include([m4/esl_avx512.m4])
 m4_include([m4/esl_neon.m4])
 m4_include([m4/esl_vmx.m4])
+m4_include([m4/esl_ieee_comp.m4])
+m4_include([m4/esl_isnan_float.m4])
+m4_include([m4/esl_isnan_double.m4])
 
 m4_include([m4/ax_mpi.m4])
 m4_include([m4/ax_pthread.m4])
@@ -77,7 +80,7 @@ AC_MSG_NOTICE([Configuring the Easel library for your system.])
 
 # remember if the user is overriding CFLAGS
 esl_cflags_env_set=no
-if test x"$CFLAGS" != x; then 
+if test x"$CFLAGS" != x; then
   esl_cflags_env_set=yes
 fi
 
@@ -88,7 +91,7 @@ fi
 ################################################################
 #
 # AC_INIT args set these output variables and preprocessor symbols:
-#     PACKAGE_NAME      <package>     e.g. "Easel"                      
+#     PACKAGE_NAME      <package>     e.g. "Easel"
 #     PACKAGE_VERSION   <version>     e.g. "0.44"
 #     PACKAGE_BUGREPORT <bug-report>  e.g. "sean@eddylab.org"
 #     PACKAGE_TARNAME   <tarname>     e.g. "easel"
@@ -129,10 +132,10 @@ AC_DEFINE_UNQUOTED([EASEL_URL],       ["$EASEL_URL"],       [Easel web URL])
 
 
 # Figure out what host we're compiling on.
-# Three GNU scripts must be included in the distro: 
+# Three GNU scripts must be included in the distro:
 #       install.sh, config.guess, config.sub
 # This sets four shell variables:
-#       host            example: i686-pc-linux-gnu      
+#       host            example: i686-pc-linux-gnu
 #       host_cpu        example: i686
 #       host_vendor     example: pc
 #       host_os         example: linux-gnu
@@ -208,12 +211,12 @@ fi
 #  --enable-gcov, --enable-gprof, and --enable-debugging are mutually exclusive.
 #
 if test "$enable_gcov" = "yes"; then
-   if test "$sre_cflags_env_set" = "yes"; then 
+   if test "$sre_cflags_env_set" = "yes"; then
      AC_MSG_ERROR([--enable-gcov overrides CFLAGS, so don't set CFLAGS])
    fi
    CFLAGS="-g -Wall -fprofile-arcs -ftest-coverage"
 elif test "$enable_gprof" = "yes"; then
-   if test "$sre_cflags_env_set" = "yes"; then 
+   if test "$sre_cflags_env_set" = "yes"; then
      AC_MSG_ERROR([--enable-gprof overrides CFLAGS, so don't set CFLAGS])
    fi
    CFLAGS="-O -g -pg"
@@ -228,7 +231,7 @@ fi
 
 # MPI :  set @CC@ to mpicc;
 #        set @MPILIBS@ if needed (usually not; mpicc deals w/ it);
-#        defines HAVE_MPI. 
+#        defines HAVE_MPI.
 if test "$enable_mpi" = "yes"; then
    AX_MPI(,AC_MSG_ERROR([MPI library not found for --enable-mpi]))
    CC=$MPICC
@@ -250,6 +253,12 @@ if test "$enable_threads" != "no"; then
     ])
 fi
 
+ESL_IEEE_COMP
+ESL_ISNAN_FLOAT
+ESL_ISNAN_DOUBLE
+if test "$c_isnan_double_works" == no ; then
+  AC_MSG_FAILURE([isnan is not working for double NaNs. Hint: disable optimizations. Ex.: by defining CFLAGS=-O0.])
+fi
 
 # Support for vector implementations (xref SRE:H3/28)
 #
@@ -264,7 +273,7 @@ fi
 #     "AVX512" requires the F, ER, and BW subsets.
 #
 # If we were explicitly told to enable one ($enable_foo="yes") and we
-# can't, fail with an error. 
+# can't, fail with an error.
 #
 # If we're autodetecting ($enable_foo="check"), set $enable_foo to the
 # result ("yes" or "no").
@@ -377,7 +386,7 @@ AC_MSG_CHECKING([whether flush-to-zero (FTZ) is supported])
 AC_COMPILE_IFELSE(
   [AC_LANG_PROGRAM(
     [#include <xmmintrin.h>],
-    [_MM_SET_FLUSH_ZERO_MODE (_MM_FLUSH_ZERO_ON);])], 
+    [_MM_SET_FLUSH_ZERO_MODE (_MM_FLUSH_ZERO_ON);])],
   [ AC_MSG_RESULT([yes])
     AC_DEFINE([HAVE_FLUSH_ZERO_MODE], 1, [Set to support FTZ, flush-to-zero mode])],
   [ AC_MSG_RESULT([no]) ])
@@ -386,7 +395,7 @@ AC_MSG_CHECKING([whether denormals-are-zero (DAZ) is supported])
 AC_COMPILE_IFELSE(
   [AC_LANG_PROGRAM(
     [#include <pmmintrin.h>],
-    [_MM_SET_DENORMALS_ZERO_MODE (_MM_DENORMALS_ZERO_ON);])], 
+    [_MM_SET_DENORMALS_ZERO_MODE (_MM_DENORMALS_ZERO_ON);])],
   [ AC_MSG_RESULT([yes])
     AC_DEFINE([HAVE_DENORMALS_ZERO_MODE], 1, [Set to support DAZ, denormals-are-zero mode])],
   [ AC_MSG_RESULT([no]) ])
@@ -405,10 +414,10 @@ fi
 
 
 # We need python, specifically python3, for 'make check' and
-# some dev tools. Makefiles check for themselves, but we 
+# some dev tools. Makefiles check for themselves, but we
 # also check in ./configure, so we don't recommend
 # 'make check' to the user if they can't use it.
-# 
+#
 AC_PATH_PROG([PYTHON3], [python3])
 
 
@@ -417,7 +426,7 @@ AC_PATH_PROG([PYTHON3], [python3])
 #################################################################
 LIBGSL=
 AS_IF([test "x$with_gsl" != xno],
-      [AC_CHECK_LIB([gsl], [gsl_expm1], 
+      [AC_CHECK_LIB([gsl], [gsl_expm1],
            [AC_SUBST([LIBGSL], ["-lgsl -lgslcblas"])
             AC_DEFINE([HAVE_LIBGSL], [1], [Define if you have libgsl])
            ],
@@ -453,7 +462,7 @@ AC_CHECK_HEADERS([\
 # <sys/param.h> and autoconf needs special logic to deal w. this as
 # follows.
 AC_CHECK_HEADERS([sys/param.h])
-AC_CHECK_HEADERS([sys/sysctl.h], [], [], 
+AC_CHECK_HEADERS([sys/sysctl.h], [], [],
 [[#ifdef HAVE_SYS_PARAM_H
 #include <sys/param.h>
 #endif
@@ -465,7 +474,7 @@ AC_CHECK_HEADERS([sys/sysctl.h], [], [],
 # 8. Checks for types
 ################################################################
 #    - Define WORDS_BIGENDIAN on bigendian platforms.
-#    - Make sure we have C99 exact-size integer types; 
+#    - Make sure we have C99 exact-size integer types;
 #      ssi uses 16, 32, and 64-bit ints, and we
 #      use 8-bit unsigned chars for digitized sequence.
 #    - Make sure we have off_t.
@@ -491,20 +500,20 @@ AC_TYPE_OFF_T
 #################################################################
 
 # __attribute__() tags on function declarations
-# HAVE_FUNC_ATTRIBUTE_NORETURN 
+# HAVE_FUNC_ATTRIBUTE_NORETURN
 #
 #   The clang static analyzer can't figure out that some of our
 #   varargs-dependent fatal error handlers (esl_fatal(), for example)
 #   cannot return. To tell it so, we take advantage of __attribute__
 #   tags on function declarations, a non-ISO gcc extension, when
 #   available. gcc, clang, and other gcc-like compilers support this.
-# 
+#
 AX_GCC_FUNC_ATTRIBUTE(noreturn)
 
 # HAVE_FUNC_ATTRIBUTE_FORMAT
-#   
+#
 #   We have some printf()-style functions that use varargs.
-#   Apparently when you do something like 
+#   Apparently when you do something like
 #           int64_t bigint;
 #           my_printf("%d", bigint);
 #   a compiler can't normally detect the size mismatch between the
@@ -515,7 +524,6 @@ AX_GCC_FUNC_ATTRIBUTE(noreturn)
 #   compiler to typecheck printf()-like arguments, and warn appropriately.
 #   We only need or use this in development.
 AX_GCC_FUNC_ATTRIBUTE(format)
-
 
 ################################################################
 # 11. Checks for library functions: define HAVE_FOO
@@ -617,13 +625,12 @@ PTHREAD_CFLAGS= $PTHREAD_CFLAGS
     VMX_CFLAGS= $VMX_CFLAGS
 
 Vector implementations enabled:
-           sse: $enable_sse
-          sse4: $enable_sse4
-           avx: $enable_avx
-        avx512: $enable_avx512
-          neon: $enable_neon
-           vmx: $enable_vmx"
-
+           sse= $enable_sse
+          sse4= $enable_sse4
+           avx= $enable_avx
+        avx512= $enable_avx512
+          neon= $enable_neon
+           vmx= $enable_vmx"
 
 if test ${PYTHON3}; then echo "
 Now do 'make' to build Easel, and optionally:

--- a/easel.c
+++ b/easel.c
@@ -2222,7 +2222,6 @@ esl_FCompareAbs(float a, float b, float tol)
   return eslFAIL;
 }
 
-
 /* Function:  esl_{DF}CompareNew()
  * Synopsis:  Compare floating point values for approximate equality, better version.
  * Incept:    SRE, Thu 19 Jul 2018 [Benasque]
@@ -2290,8 +2289,12 @@ esl_DCompareNew(double x0, double x, double r_tol, double a_tol)
 int
 esl_FCompareNew(float x0, float x, float r_tol, float a_tol)
 {
+#if !defined(HAVE_IEEE_COMPARISONS)
+  if (esl_isnanf(x0)) return eslFAIL;
+  if (esl_isnanf(x)) return eslFAIL;
+#endif
   if (isfinite(x0)) { if (fabs(x0 - x) <= r_tol * fabs(x0) + a_tol) return eslOK; }
-  else              { if (x0 == x) return eslOK; }                                   
+  else              { if (x0 == x) return eslOK; }
   return eslFAIL;
 }
 

--- a/easel.h
+++ b/easel.h
@@ -475,6 +475,16 @@ extern int  esl_strtok_adv(char **s, char *delim, char **ret_tok, int *opt_tokle
 extern int  esl_sprintf (char **ret_s, const char *format, ...);
 extern int  esl_vsprintf(char **ret_s, const char *format, va_list *ap);
 extern int  esl_strcmp(const char *s1, const char *s2);
+static inline int esl_isnanf(float x)
+{
+#if !defined(ISNAN_FLOAT_WORKS)
+  int *a = (int*) &x;
+  return (((0xFF << 23) & *a) == (0xFF << 23)) && (0x7FFFFF & *a) != 0;
+#else
+  return isnan(x);
+#endif
+}
+
 
 /* 5.  Portable drop-in replacements for non-standard C functions */
 #ifndef HAVE_STRCASECMP

--- a/esl_buffer.c
+++ b/esl_buffer.c
@@ -2794,10 +2794,10 @@ utest_halfnewline(void)
 
 static ESL_OPTIONS options[] = {
    /* name  type         default  env   range togs  reqs  incomp  help                docgrp */
-  {"-h",  eslARG_NONE,    FALSE, NULL, NULL, NULL, NULL, NULL, "show help and usage",                            0},
-  {"-n",  eslARG_INT,   "10000", NULL, NULL, NULL, NULL, NULL, "set number of lines in line-based tests to <n>", 0},
-  {"-s",  eslARG_INT,       "0", NULL, NULL, NULL, NULL, NULL, "set random number seed to <n>",                  0},
-  {"-v",  eslARG_NONE,    FALSE, NULL, NULL, NULL, NULL, NULL, "show verbose commentary/output",                 0},
+  {"-h",  eslARG_NONE,  FALSE, NULL, NULL, NULL, NULL, NULL, "show help and usage",                            0},
+  {"-n",  eslARG_INT,   "100", NULL, NULL, NULL, NULL, NULL, "set number of lines in line-based tests to <n>", 0},
+  {"-s",  eslARG_INT,     "0", NULL, NULL, NULL, NULL, NULL, "set random number seed to <n>",                  0},
+  {"-v",  eslARG_NONE,  FALSE, NULL, NULL, NULL, NULL, NULL, "show verbose commentary/output",                 0},
   { 0,0,0,0,0,0,0,0,0,0},
 };
 static char usage[]  = "[-options]";

--- a/esl_config.h.in
+++ b/esl_config.h.in
@@ -36,6 +36,9 @@
 
 #undef HAVE_FLUSH_ZERO_MODE        // on x86 platforms: we can turn off denormalized floating point math,
 #undef HAVE_DENORMALS_ZERO_MODE    //   which often incurs performance penalty. See simdvec.md in HMMER.
+#undef ISNAN_FLOAT_WORKS
+#undef ISNAN_DOUBLE_WORKS
+#undef HAVE_IEEE_COMPARISONS
 
 #undef HAVE_MPI
 #undef HAVE_PTHREAD

--- a/esl_json.c
+++ b/esl_json.c
@@ -676,7 +676,7 @@ esl_json_ReadFloat(const ESL_JSON *pi, int idx, ESL_BUFFER *bf, float *ret_x)
     }
   ESL_DASSERT1(( i == n ));
 
-  *ret_x = sign * val * powf(10.,exponent);  // range errors (over/underflow) aren't checked for; just let it go to +/-inf.
+  *ret_x = sign * val * pow(10.,exponent);  // range errors (over/underflow) aren't checked for; just let it go to +/-inf.
   return eslOK;
 }
   

--- a/esl_stats.c
+++ b/esl_stats.c
@@ -1034,7 +1034,7 @@ static ESL_OPTIONS options[] = {
   {"-h",  eslARG_NONE,    FALSE, NULL, NULL, NULL, NULL, NULL, "show help and usage",                   0},
   {"-s",  eslARG_INT,      "42", NULL, NULL, NULL, NULL, NULL, "set random number seed to <n>",         0},
   {"-v",  eslARG_NONE,    FALSE, NULL, NULL, NULL, NULL, NULL, "verbose: show verbose output",          0},
-  {"-N",  eslARG_INT,"10000000", NULL, NULL, NULL, NULL, NULL, "number of trials in LogGamma test",     0},
+  {"-N",  eslARG_INT,  "100000", NULL, NULL, NULL, NULL, NULL, "number of trials in LogGamma test",     0},
   { 0,0,0,0,0,0,0,0,0,0},
 };
 static char usage[]  = "[-options]";

--- a/esl_vectorops.c
+++ b/esl_vectorops.c
@@ -1762,6 +1762,7 @@ utest_pvectors(void)
   float  p3f[4];
   int    n = 4;
   double result;
+  float resultf;
 
   esl_vec_D2F(p1,  n, p1f);
   esl_vec_F2D(p2f, n, p2);  
@@ -1777,8 +1778,8 @@ utest_pvectors(void)
   result = esl_vec_DRelEntropy(p2,  p1,  n);  if (esl_DCompare(1.0, result, 1e-9) != eslOK) esl_fatal(msg);
   result = esl_vec_FRelEntropy(p2f, p1f, n);  if (esl_DCompare(1.0, result, 1e-9) != eslOK) esl_fatal(msg);
 
-  result = esl_vec_DRelEntropy(p1,  p2,  n);  if (result != eslINFINITY)  esl_fatal(msg);
-  result = esl_vec_FRelEntropy(p1f, p2f, n);  if (result != eslINFINITY)  esl_fatal(msg);
+  result = esl_vec_DRelEntropy(p1,  p2,  n);  if (isfinite(result))  esl_fatal(msg);
+  resultf = esl_vec_FRelEntropy(p1f, p2f, n); if (isfinite(resultf)) esl_fatal(msg);
 
   esl_vec_DLog(p2, n);
   if (esl_vec_DLogValidate(p2, n, 1e-12, NULL) != eslOK) esl_fatal(msg);

--- a/esl_vmx.c
+++ b/esl_vmx.c
@@ -323,7 +323,6 @@ utest_logf(ESL_GETOPTS *go)
   }
   if (isinf(r.x[0]) != 1)  esl_fatal("logf(inf)  should be inf");
   if (! isnan(r.x[1]))     esl_fatal("logf(NaN)  should be NaN");
-
 }
 
 /* utest_expf():  Test range/domain of expf */

--- a/m4/esl_ieee_comp.m4
+++ b/m4/esl_ieee_comp.m4
@@ -1,0 +1,38 @@
+# SYNOPSIS
+#
+#   ESL_IEEE_COMP
+#
+# DESCRIPTION
+#
+#   Let <x> be a floating point variable. IEEE 754-1985 establishes that "x == x" is
+#   always false when x represents a NaN (not-a-number). This function will define
+#   HAVE_IEEE_COMPARISONS when this is indeed the case.
+#
+# ACKNOWLEDGMENT
+#
+#   Based on the source code of the GSL - GNU Scientific Library.
+
+AC_DEFUN([ESL_IEEE_COMP], [
+  AC_MSG_CHECKING([whether it complies with IEEE comparisons])
+
+  AC_RUN_IFELSE([AC_LANG_SOURCE([[
+    #include <math.h>
+    #ifndef NAN
+    #define NAN (0./0.)
+    #endif
+    int main (void)
+    {
+      int status;
+      float nanf = NAN;
+      double nand = NAN;
+      status = (nanf == nanf) | (nand == nand);
+      exit (status);
+    }
+  ]])],
+    [c_ieee_comparisons="yes"; AC_MSG_RESULT(yes)],
+    [c_ieee_comparisons="no"; AC_MSG_RESULT(no)])
+
+  if test "$c_ieee_comparisons" != no ; then
+    AC_DEFINE(HAVE_IEEE_COMPARISONS,1,[Define this if IEEE comparisons work correctly (e.g. NaN != NaN)])
+  fi
+])

--- a/m4/esl_isnan_double.m4
+++ b/m4/esl_isnan_double.m4
@@ -1,0 +1,32 @@
+# SYNOPSIS
+#
+#   ESL_ISNAN_DOUBLE
+#
+# DESCRIPTION
+#
+#   Check whether isnan works for double NaNs. This function will define
+#   ISNAN_DOUBLE_WORKS when this is indeed the case.
+
+AC_DEFUN([ESL_ISNAN_DOUBLE], [
+  AC_MSG_CHECKING([whether isnan works for double NaNs])
+
+  AC_RUN_IFELSE([AC_LANG_SOURCE([[
+    #include <math.h>
+    #ifndef NAN
+    #define NAN (0./0.)
+    #endif
+    int main (void)
+    {
+      int status;
+      double nan = NAN;
+      status = !isnan(nan);
+      exit (status);
+    }
+  ]])],
+    [c_isnan_double_works="yes"; AC_MSG_RESULT(yes)],
+    [c_isnan_double_works="no"; AC_MSG_RESULT(no)])
+
+  if test "$c_isnan_double_works" != no ; then
+    AC_DEFINE(ISNAN_DOUBLE_WORKS,1,[Define this if isnan works for double NaNs])
+  fi
+])

--- a/m4/esl_isnan_float.m4
+++ b/m4/esl_isnan_float.m4
@@ -1,0 +1,32 @@
+# SYNOPSIS
+#
+#   ESL_ISNAN_FLOAT
+#
+# DESCRIPTION
+#
+#   Check whether isnan works for float NaNs. This function will define
+#   ISNAN_FLOAT_WORKS when this is indeed the case.
+
+AC_DEFUN([ESL_ISNAN_FLOAT], [
+  AC_MSG_CHECKING([whether isnan works for float NaNs])
+
+  AC_RUN_IFELSE([AC_LANG_SOURCE([[
+    #include <math.h>
+    #ifndef NAN
+    #define NAN (0./0.)
+    #endif
+    int main (void)
+    {
+      int status;
+      float nan = NAN;
+      status = !isnan(nan);
+      exit (status);
+    }
+  ]])],
+    [c_isnan_float_works="yes"; AC_MSG_RESULT(yes)],
+    [c_isnan_float_works="no"; AC_MSG_RESULT(no)])
+
+  if test "$c_isnan_float_works" != no ; then
+    AC_DEFINE(ISNAN_FLOAT_WORKS,1,[Define this if isnan works for float NaNs])
+  fi
+])

--- a/m4/esl_vmx.m4
+++ b/m4/esl_vmx.m4
@@ -33,7 +33,7 @@ AC_DEFUN([ESL_VMX], [
       *)    CFLAGS="$save_CFLAGS $esl_vmx_cflags";;
     esac
 
-    AC_LINK_IFELSE(
+    AC_RUN_IFELSE(
       [AC_LANG_SOURCE([[
 #include <altivec.h>
 #include <stdint.h>


### PR DESCRIPTION
The travis tests are now passing on the PPC 32-bits platform. Under that platform (at least when emulated via qemu), nan == nan fail, isnanf won't identify NAN when gcc optimization flag is used (gcc 4.9). I have decreased the number of trials for some esl_stats.c test as it was very slow to run that test on a slow, emulated machine. I also removed trailing whitespaces from some files.