### PR TITLE
Enable position independent code compilation, via --enable-pic configure option

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -58,6 +58,7 @@ man1ext     = .1
 CC             = @CC@
 CFLAGS         = @CFLAGS@ 
 PTHREAD_CFLAGS = @PTHREAD_CFLAGS@ 
+PIC_CFLAGS     = @PIC_CFLAGS@
 SSE_CFLAGS     = @SSE_CFLAGS@ @SSE4_CFLAGS@
 AVX_CFLAGS     = @AVX_CFLAGS@
 AVX512_CFLAGS  = @AVX512_CFLAGS@
@@ -548,7 +549,7 @@ libeasel.a:  ${ALL_OBJS}
 	@${RANLIB} libeasel.a
 
 ${ALL_OBJS}: %.o : %.c ${HDRS} esl_config.h
-	${QUIET_CC}${CC} -I. -I${srcdir} ${CFLAGS} ${PTHREAD_CFLAGS} ${SIMD_CFLAGS} ${DEFS} -c $<
+	${QUIET_CC}${CC} -I. -I${srcdir} ${CFLAGS} ${PTHREAD_CFLAGS} ${PIC_CFLAGS} ${SIMD_CFLAGS} ${DEFS} -c $<
 
 
 # Driver compilation:
@@ -572,10 +573,10 @@ ${ALL_UTESTS}:  libeasel.a
 	   else DFILE=${srcdir}/esl_$${BASENAME}.c ;\
         fi;\
 	if test ${V} ;\
-	   then echo "${CC} ${CFLAGS} ${PTHREAD_CFLAGS} ${UTEST_CFLAGS} ${DEFS} ${LDFLAGS} -o $@ -I. -I${srcdir} -L. -D$${DFLAG} $${DFILE} -leasel -lm ${LIBS}" ;\
+	   then echo "${CC} ${CFLAGS} ${PTHREAD_CFLAGS} ${PIC_CFLAGS} ${UTEST_CFLAGS} ${DEFS} ${LDFLAGS} -o $@ -I. -I${srcdir} -L. -D$${DFLAG} $${DFILE} -leasel -lm ${LIBS}" ;\
 	   else echo '    ' GEN $@ ;\
 	fi ;\
-	${CC} ${CFLAGS} ${PTHREAD_CFLAGS} ${SIMD_CFLAGS} ${DEFS} ${LDFLAGS} -o $@ -I. -I${srcdir} -L. -D$${DFLAG} $${DFILE} -leasel -lm ${LIBS}
+	${CC} ${CFLAGS} ${PTHREAD_CFLAGS} ${PIC_CFLAGS} ${SIMD_CFLAGS} ${DEFS} ${LDFLAGS} -o $@ -I. -I${srcdir} -L. -D$${DFLAG} $${DFILE} -leasel -lm ${LIBS}
 
 ${ALL_BENCHMARKS}: libeasel.a
 	@BASENAME=`echo $@ | sed -e 's/_benchmark//'| sed -e 's/^esl_//'` ;\
@@ -586,10 +587,10 @@ ${ALL_BENCHMARKS}: libeasel.a
 	   else DFILE=${srcdir}/esl_$${BASENAME}.c ;\
         fi;\
 	if test ${V} ;\
-	   then echo "${CC} ${CFLAGS} ${PTHREAD_CFLAGS} ${SIMDFLAGS} ${DEFS} ${LDFLAGS} -o $@ -I. -I${srcdir} -L. -D$${DFLAG} $${DFILE} -leasel -lm ${LIBS}" ;\
+	   then echo "${CC} ${CFLAGS} ${PTHREAD_CFLAGS} ${PIC_CFLAGS} ${SIMDFLAGS} ${DEFS} ${LDFLAGS} -o $@ -I. -I${srcdir} -L. -D$${DFLAG} $${DFILE} -leasel -lm ${LIBS}" ;\
 	   else echo '    ' GEN $@ ;\
 	fi ;\
-	${CC} ${CFLAGS} ${PTHREAD_CFLAGS} ${SIMD_CFLAGS} ${DEFS} ${LDFLAGS} -o $@ -I. -I${srcdir} -L. -D$${DFLAG} $${DFILE} -leasel -lm ${LIBS}
+	${CC} ${CFLAGS} ${PTHREAD_CFLAGS} ${PIC_CFLAGS} ${SIMD_CFLAGS} ${DEFS} ${LDFLAGS} -o $@ -I. -I${srcdir} -L. -D$${DFLAG} $${DFILE} -leasel -lm ${LIBS}
 
 ${ALL_EXPERIMENTS}: libeasel.a
 	@BASENAME=`echo $@ | sed -e 's/_experiment//'| sed -e 's/^esl_//'` ;\
@@ -600,10 +601,10 @@ ${ALL_EXPERIMENTS}: libeasel.a
 	   else DFILE=${srcdir}/esl_$${BASENAME}.c ;\
         fi;\
 	if test ${V} ;\
-	   then echo "${CC} ${CFLAGS} ${PTHREAD_CFLAGS} ${SIMDFLAGS} ${DEFS} ${LDFLAGS} -o $@ -I. -I${srcdir} -L. -D$${DFLAG} $${DFILE} -leasel -lm ${LIBS}" ;\
+	   then echo "${CC} ${CFLAGS} ${PTHREAD_CFLAGS} ${PIC_CFLAGS} ${SIMDFLAGS} ${DEFS} ${LDFLAGS} -o $@ -I. -I${srcdir} -L. -D$${DFLAG} $${DFILE} -leasel -lm ${LIBS}" ;\
 	   else echo '    ' GEN $@ ;\
 	fi ;\
-	${CC} ${CFLAGS} ${PTHREAD_CFLAGS} ${SIMD_CFLAGS} ${DEFS} ${LDFLAGS} -o $@ -I. -I${srcdir} -L. -D$${DFLAG} $${DFILE} -leasel -lm ${LIBS}
+	${CC} ${CFLAGS} ${PTHREAD_CFLAGS} ${PIC_CFLAGS} ${SIMD_CFLAGS} ${DEFS} ${LDFLAGS} -o $@ -I. -I${srcdir} -L. -D$${DFLAG} $${DFILE} -leasel -lm ${LIBS}
 
 ${ALL_EXAMPLES}: libeasel.a
 	@BASENAME=`echo $@ | sed -e 's/_example[0-9]*//'| sed -e 's/^esl_//'` ;\
@@ -613,10 +614,10 @@ ${ALL_EXAMPLES}: libeasel.a
            else DFILE=${srcdir}/esl_$${BASENAME}.c ;\
         fi ;\
 	if test ${V}; \
-	   then echo "${CC} ${CFLAGS} ${PTHREAD_CFLAGS} ${SIMDFLAGS} ${DEFS} ${LDFLAGS} -o $@ -I. -I${srcdir} -L. -D$${DFLAG} $${DFILE} -leasel -lm ${LIBS}" ;\
+	   then echo "${CC} ${CFLAGS} ${PTHREAD_CFLAGS} ${PIC_CFLAGS} ${SIMDFLAGS} ${DEFS} ${LDFLAGS} -o $@ -I. -I${srcdir} -L. -D$${DFLAG} $${DFILE} -leasel -lm ${LIBS}" ;\
 	   else echo '    ' GEN $@ ;\
 	fi ;\
-	${CC} ${CFLAGS} ${PTHREAD_CFLAGS} ${SIMD_CFLAGS} ${DEFS} ${LDFLAGS} -o $@ -I. -I${srcdir} -L. -D$${DFLAG} $${DFILE} -leasel -lm ${LIBS}
+	${CC} ${CFLAGS} ${PTHREAD_CFLAGS} ${PIC_CFLAGS} ${SIMD_CFLAGS} ${DEFS} ${LDFLAGS} -o $@ -I. -I${srcdir} -L. -D$${DFLAG} $${DFILE} -leasel -lm ${LIBS}
 
 
 

--- a/configure.ac
+++ b/configure.ac
@@ -68,6 +68,7 @@ m4_include([m4/esl_vmx.m4])
 m4_include([m4/ax_mpi.m4])
 m4_include([m4/ax_pthread.m4])
 
+m4_include([m4/esl_pic_flags.m4])
 
 ################################################################
 # 2. AC_INIT
@@ -182,6 +183,7 @@ AC_ARG_ENABLE(mpi,     [AS_HELP_STRING([--enable-mpi],     [enable MPI paralleli
 
 AC_ARG_WITH(gsl,       [AS_HELP_STRING([--with-gsl],       [use the GSL, GNU Scientific Library])],     with_gsl=$withval,         with_gsl=no)
 
+AC_ARG_ENABLE(pic,     [AS_HELP_STRING([--enable-pic],     [enable position-independent code])],        enable_pic=$enableval,     enable_pic=no)
 
 
 
@@ -232,6 +234,13 @@ fi
 if test "$enable_mpi" = "yes"; then
    AX_MPI(,AC_MSG_ERROR([MPI library not found for --enable-mpi]))
    CC=$MPICC
+fi
+
+
+
+# PIC :
+if test "$enable_pic" = "yes"; then
+   ESL_PIC_FLAGS
 fi
 
 
@@ -614,6 +623,7 @@ PTHREAD_CFLAGS= $PTHREAD_CFLAGS
  AVX512_CFLAGS= $AVX512_CFLAGS
    NEON_CFLAGS= $NEON_CFLAGS
     VMX_CFLAGS= $VMX_CFLAGS
+    PIC_CFLAGS= $PIC_CFLAGS
 
 Vector implementations enabled:
            sse: $enable_sse

--- a/m4/esl_pic_flags.m4
+++ b/m4/esl_pic_flags.m4
@@ -1,0 +1,134 @@
+# ===========================================================================
+#   http://www.mesa3d.org/
+#   http://www.mail-archive.com/mesa3d-dev@lists.sourceforge.net/msg04938.html
+#   https://gitlab.freedesktop.org/lima/mesa/commit/d368eed9c78aa3ced8540c66bdc4c5e1d4a067b4
+# ===========================================================================
+#
+# SYNOPSIS
+#
+#   ESL_PIC_FLAGS
+#
+# DESCRIPTION
+# 
+# Derived (essentially verbatim) from MESA_PIC_FLAGS, in the Mesa
+# project's acinclude.m4 file originally written by Dan Nicholson in 2012
+# according to https://gitlab.freedesktop.org/lima/mesa/commit/d368eed9c78aa3ced8540c66bdc4c5e1d4a067b4
+# From the Mesa file's header:
+#   "Find out whether to build PIC code using the option --enable-pic and
+#   the configure enable_static/enable_shared settings. If PIC is needed,
+#   figure out the necessary flags for the platform and compiler.
+#
+#   The platform checks have been shamelessly taken from libtool and
+#   stripped down to just what's needed for Mesa. See _LT_COMPILER_PIC in
+#   /usr/share/aclocal/libtool.m4 or
+#   http://git.savannah.gnu.org/gitweb/?p=libtool.git;a=blob;f=libltdl/m4/libtool.m4;hb=HEAD
+#
+# Sets an output variable @PIC_CFLAGS@ which should be added to
+# CFLAGS lines.
+#
+#
+AC_DEFUN([ESL_PIC_FLAGS],
+[AC_REQUIRE([AC_PROG_CC])dnl
+AC_ARG_VAR([PIC_CFLAGS], [compiler flags for PIC code])
+AC_ARG_ENABLE([pic],
+    [AS_HELP_STRING([--disable-pic],
+        [compile PIC objects @<:@default=enabled for shared builds
+        on supported platforms@:>@])],
+    [enable_pic="$enableval"
+    test "x$enable_pic" = x && enable_pic=auto],
+    [enable_pic=auto])
+# disable PIC by default for static builds
+if test "$enable_pic" = auto && test "$enable_static" = yes; then
+    enable_pic=no
+fi
+# if PIC hasn't been explicitly disabled, try to figure out the flags
+if test "$enable_pic" != no; then
+    AC_MSG_CHECKING([for $CC option to produce PIC])
+    # allow the user's flags to override
+    if test "x$PIC_CFLAGS" = x; then
+        # see if we're using GCC
+        if test "x$GCC" = xyes; then
+            case "$host_os" in
+            aix*|beos*|cygwin*|irix5*|irix6*|osf3*|osf4*|osf5*)
+                # PIC is the default for these OSes.
+                ;;
+            mingw*|os2*|pw32*)
+                # This hack is so that the source file can tell whether
+                # it is being built for inclusion in a dll (and should
+                # export symbols for example).
+                PIC_CFLAGS="-DDLL_EXPORT"
+                ;;
+            darwin*|rhapsody*)
+                # PIC is the default on this platform
+                # Common symbols not allowed in MH_DYLIB files
+                PIC_CFLAGS="-fno-common"
+                ;;
+            hpux*)
+                # PIC is the default for IA64 HP-UX and 64-bit HP-UX,
+                # but not for PA HP-UX.
+                case $host_cpu in
+                hppa*64*|ia64*)
+                    ;;
+                *)
+                    PIC_CFLAGS="-fPIC"
+                    ;;
+                esac
+                ;;
+            *)
+                # Everyone else on GCC uses -fPIC
+                PIC_CFLAGS="-fPIC"
+                ;;
+            esac
+        else # !GCC
+            case "$host_os" in
+            hpux9*|hpux10*|hpux11*)
+                # PIC is the default for IA64 HP-UX and 64-bit HP-UX,
+                # but not for PA HP-UX.
+                case "$host_cpu" in
+                hppa*64*|ia64*)
+                    # +Z the default
+                    ;;
+                *)
+                    PIC_CFLAGS="+Z"
+                    ;;
+                esac
+                ;;
+            linux*|k*bsd*-gnu)
+                case `basename "$CC"` in
+                icc*|ecc*|ifort*)
+                    PIC_CFLAGS="-KPIC"
+                    ;;
+                pgcc*|pgf77*|pgf90*|pgf95*)
+                    # Portland Group compilers (*not* the Pentium gcc
+                    # compiler, which looks to be a dead project)
+                    PIC_CFLAGS="-fpic"
+                    ;;
+                ccc*)
+                    # All Alpha code is PIC.
+                    ;;
+                xl*)
+                    # IBM XL C 8.0/Fortran 10.1 on PPC
+                    PIC_CFLAGS="-qpic"
+                    ;;
+                *)
+                    case `$CC -V 2>&1 | sed 5q` in
+                    *Sun\ C*|*Sun\ F*)
+                        # Sun C 5.9 or Sun Fortran
+                        PIC_CFLAGS="-KPIC"
+                        ;;
+                    esac
+                esac
+                ;;
+            solaris*)
+                PIC_CFLAGS="-KPIC"
+                ;;
+            sunos4*)
+                PIC_CFLAGS="-PIC"
+                ;;
+            esac
+        fi # GCC
+    fi # PIC_CFLAGS
+    AC_MSG_RESULT([$PIC_CFLAGS])
+fi
+AC_SUBST([PIC_CFLAGS])
+])


### PR DESCRIPTION
Brings back code from aclocal.m4 of 0.43 release (bdfb76a) and puts it in m4/esl_pic_flags.m4 for detecting --enable-pic option to configure and calling ESL_PIC_FLAGS function that sets PIC_CFLAGS variable based on compiler. I didn't try too hard to match other conventions for m4 files in esl_pic_flags.m4, for fear that I would break something in the original 0.43 code, and because it wasn't entirely clear what those conventions were or how much you care about them.

Motivation for this is the Bio-Easel perl library, which requires position independent code to use easel as a library and call easel functions via Inline perl.

I tested configure with and without --enable-pic on:
1) gcc 7.3.0 (at NCBI)
2) Apple LLVM version 10.0.1 (clang-1001.0.46.4) (on my iMac)
3) gcc 4.8.5 20150623 (Red Hat 4.8.5-11) (at EBI)

Everything passed and looks good to me related to my changes, but unit test 4 failed on both gccs:

exercise    4 [            avx-utest] ...     FAILED [crash!]

I verified this unit test also fails on the current revision in 'develop' branch (commit 6802644)
Let me know if you want more info.