### PR TITLE
Enforces if(foo) before free(foo) in esl _Destroy() functions

### DIFF
--- a/esl_bitfield.c
+++ b/esl_bitfield.c
@@ -69,8 +69,10 @@ esl_bitfield_Count(const ESL_BITFIELD *b)
 void
 esl_bitfield_Destroy(ESL_BITFIELD *b)
 {
-  if (b) free(b->b);
-  free(b);
+  if (b) { 
+    free(b->b);
+    free(b);
+  }
 }
 
 

--- a/esl_huffman.c
+++ b/esl_huffman.c
@@ -157,12 +157,12 @@ void
 esl_huffman_Destroy(ESL_HUFFMAN *hc)
 {
   if (hc) {
-    free(hc->len);
-    free(hc->code);
-    free(hc->sorted_at);
-    free(hc->dt_len);
-    free(hc->dt_lcode);
-    free(hc->dt_rank);
+    if(hc->len)       free(hc->len);
+    if(hc->code)      free(hc->code);
+    if(hc->sorted_at) free(hc->sorted_at);
+    if(hc->dt_len)    free(hc->dt_len);
+    if(hc->dt_lcode)  free(hc->dt_lcode);
+    if(hc->dt_rank)   free(hc->dt_rank);
     free(hc);
   }
 }

--- a/esl_json.c
+++ b/esl_json.c
@@ -482,7 +482,7 @@ esl_json_Destroy(ESL_JSON *pi)
 {
   if (pi)
     {
-      free(pi->tok);
+      if(pi->tok) free(pi->tok);
       free(pi);
     }
 }

--- a/esl_minimizer.c
+++ b/esl_minimizer.c
@@ -297,7 +297,7 @@ esl_min_cfg_Destroy(ESL_MIN_CFG *cfg)
 {
   if (cfg)
     {
-      free(cfg->u);
+      if(cfg->u) free(cfg->u);
       free(cfg);
     }
 }

--- a/esl_mixdchlet.c
+++ b/esl_mixdchlet.c
@@ -81,9 +81,9 @@ esl_mixdchlet_Destroy(ESL_MIXDCHLET *dchl)
 {
   if (dchl)
     {
-      free(dchl->q);
+      if(dchl->q)     free(dchl->q);
       esl_mat_DDestroy(dchl->alpha);
-      free(dchl->postq);
+      if(dchl->postq) free(dchl->postq);
       free(dchl);
     }
 }

--- a/esl_msaweight.c
+++ b/esl_msaweight.c
@@ -569,7 +569,7 @@ esl_msaweight_cfg_Create(void)
 void
 esl_msaweight_cfg_Destroy(ESL_MSAWEIGHT_CFG *cfg)
 {
-  free(cfg);
+  if(cfg) free(cfg);
 }
 
 

--- a/esl_rand64.c
+++ b/esl_rand64.c
@@ -145,7 +145,7 @@ esl_rand64_GetSeed(ESL_RAND64 *rng)
 void
 esl_rand64_Destroy(ESL_RAND64 *rng)
 {
-  free(rng);
+  if(rng) free(rng);
 }
 
 

--- a/esl_random.c
+++ b/esl_random.c
@@ -249,7 +249,7 @@ esl_randomness_GetSeed(const ESL_RANDOMNESS *r)
 void
 esl_randomness_Destroy(ESL_RANDOMNESS *r)
 {
-  free(r);
+  if(r) free(r);
   return;
 }
 

--- a/esl_red_black.c
+++ b/esl_red_black.c
@@ -31,13 +31,15 @@ ERROR:
 }
 
 void esl_red_black_doublekey_Destroy(ESL_RED_BLACK_DOUBLEKEY *tree){
-  if(tree->large != NULL){
-    esl_red_black_doublekey_Destroy(tree->large);
+  if(tree) { 
+    if(tree->large != NULL){
+      esl_red_black_doublekey_Destroy(tree->large);
+    }
+    if(tree->small != NULL){
+      esl_red_black_doublekey_Destroy(tree->small);
+    }
+    free(tree);
   }
-  if(tree->small != NULL){
-    esl_red_black_doublekey_Destroy(tree->small);
-  }
-  free(tree);
 }
 
 void esl_red_black_doublekey_linked_list_Destroy(ESL_RED_BLACK_DOUBLEKEY *tree){

--- a/esl_regexp.c
+++ b/esl_regexp.c
@@ -111,8 +111,10 @@ void
 esl_regexp_Destroy(ESL_REGEXP *machine)
 {
   /* Spencer's clever alloc for the NDFA allows us to free it w/ free()  */
-  if (machine->ndfa != NULL) free(machine->ndfa); 
-  free(machine);
+  if(machine) { 
+    if (machine->ndfa != NULL) free(machine->ndfa); 
+    free(machine);
+  }
   return;
 }
 


### PR DESCRIPTION
@cryptogenomicon and @npcarter  : 

***I just opened and closed a similar pull request (#44 ) between *master* and my destroy-null-check branch, which branched off develop. I closed it because the pull request should have been with develop and not master. This pull request is between develop and destroy-null-check. Sorry for the confusion.***

I found and 'fixed' 10 files with a `_Destroy()` function that did not enforce the convention that a pointer be checked for non-NULLness before calling free. I did a separate commit for each fix with the hope that it might make it easier for you to accept some and not others if that's what you want to do (but I'm not sure if it will make it easier).

The motivation for this was a bug report for a non-reproducible bug in cmscan that user provided error output for including the message 

```** glibc detected *** cmscan: double free or corruption (!prev): 0x000000000125c440 ***```

 I couldn't reproduce in my hands, but checked all possible `free()` calls and found exactly 1 that didn't check for non-NULLness before freeing (e.g. with `if(foo)` prior to `free(foo)`). That was in `esl_random.c::esl_randomness_Destroy()`. The large majority of easel `_Destroy()` functions follow the `if(foo)` before `free(foo)` convention, so I decided to go ahead and check all easel destroy functions to make sure they all did. I found 9 others that did not and propose the fixes here. 

There are 2 cases that I found that did not enforce the convention but that I did not understand well enough to propose a fix. I ask that you and Nick (who I think wrote `esl_red_black`) take a look at them and make changes if appropriate. 

1. `esl_red_black.h:void esl_red_black_doublekey_linked_list_Destroy(ESL_RED_BLACK_DOUBLEKEY *tree)`: doesn't check that tree is non-NULL at start

2. `esl_sq.c:sq_free`: doesn't check that sq is non-NULL at start
