### PR TITLE
esl_sqio_ReadBlock max init window flag

### DIFF
--- a/esl_sqio.c
+++ b/esl_sqio.c
@@ -522,9 +522,9 @@ esl_sqio_ReadWindow(ESL_SQFILE *sqfp, int C, int W, ESL_SQ *sq)
  *            <eslEINCONCEIVABLE> on internal error.
  */
 int
-esl_sqio_ReadBlock(ESL_SQFILE *sqfp, ESL_SQ_BLOCK *sqBlock, int max_residues, int max_sequences, int long_target)
+esl_sqio_ReadBlock(ESL_SQFILE *sqfp, ESL_SQ_BLOCK *sqBlock, int max_residues, int max_sequences, int max_init_window, int long_target)
 {
-  return sqfp->read_block(sqfp, sqBlock, max_residues, max_sequences, long_target);
+  return sqfp->read_block(sqfp, sqBlock, max_residues, max_sequences, max_init_window, long_target);
 }
 
 /* Function:  esl_sqio_Parse()

--- a/esl_sqio.h
+++ b/esl_sqio.h
@@ -58,7 +58,7 @@ typedef struct esl_sqio_s {
   int   (*read_window)     (struct esl_sqio_s *sqfp, int C, int W, ESL_SQ *sq);
   int   (*echo)            (struct esl_sqio_s *sqfp, const ESL_SQ *sq, FILE *ofp);
 
-  int   (*read_block)      (struct esl_sqio_s *sqfp, ESL_SQ_BLOCK *sqBlock, int max_residues, int max_sequences, int long_target);
+  int   (*read_block)      (struct esl_sqio_s *sqfp, ESL_SQ_BLOCK *sqBlock, int max_residues, int max_sequences, int max_init_window, int long_target);
 
   int   (*open_ssi)        (struct esl_sqio_s *sqfp, const char *ssifile_hint);
   int   (*pos_by_key)      (struct esl_sqio_s *sqfp, const char *key);
@@ -132,7 +132,7 @@ extern int   esl_sqio_Read        (ESL_SQFILE *sqfp, ESL_SQ *sq);
 extern int   esl_sqio_ReadInfo    (ESL_SQFILE *sqfp, ESL_SQ *sq);
 extern int   esl_sqio_ReadWindow  (ESL_SQFILE *sqfp, int C, int W, ESL_SQ *sq);
 extern int   esl_sqio_ReadSequence(ESL_SQFILE *sqfp, ESL_SQ *sq);
-extern int   esl_sqio_ReadBlock   (ESL_SQFILE *sqfp, ESL_SQ_BLOCK *sqBlock, int max_residues, int max_sequences, int long_target);
+extern int   esl_sqio_ReadBlock   (ESL_SQFILE *sqfp, ESL_SQ_BLOCK *sqBlock, int max_residues, int max_sequences, int max_init_window, int long_target);
 extern int   esl_sqio_Parse       (char *buffer, int size, ESL_SQ *s, int format);
 
 extern int   esl_sqio_Write       (FILE *fp, ESL_SQ *s, int format, int update);

--- a/esl_sqio_ascii.c
+++ b/esl_sqio_ascii.c
@@ -1425,7 +1425,7 @@ sqascii_ReadWindow(ESL_SQFILE *sqfp, int C, int W, ESL_SQ *sq)
  * 
  *            If <long_target> is true and <max_init_window> is TRUE,
  *            the first window read from each sequence (of length L)
- *            is always max(L, <max_residues>). If <max_init_window>
+ *            is always min(L, <max_residues>). If <max_init_window>
  *            is FALSE, then the length of the first window read from
  *            each sequence is calculated differently as 
  *            max(<max_residues> - <size>, <max_residues> * .05);

--- a/esl_sqio_ascii.c
+++ b/esl_sqio_ascii.c
@@ -45,7 +45,7 @@ static int   sqascii_Read           (ESL_SQFILE *sqfp, ESL_SQ *sq);
 static int   sqascii_ReadInfo       (ESL_SQFILE *sqfp, ESL_SQ *sq);
 static int   sqascii_ReadSequence   (ESL_SQFILE *sqfp, ESL_SQ *sq);
 static int   sqascii_ReadWindow     (ESL_SQFILE *sqfp, int C, int W, ESL_SQ *sq);
-static int   sqascii_ReadBlock      (ESL_SQFILE *sqfp, ESL_SQ_BLOCK *sqBlock, int max_residues, int max_sequences, int long_target);
+static int   sqascii_ReadBlock      (ESL_SQFILE *sqfp, ESL_SQ_BLOCK *sqBlock, int max_residues, int max_sequences, int max_init_window, int long_target);
 static int   sqascii_Echo           (ESL_SQFILE *sqfp, const ESL_SQ *sq, FILE *ofp);
 
 static int   sqascii_IsRewindable   (const ESL_SQFILE *sqfp);
@@ -1413,7 +1413,8 @@ sqascii_ReadWindow(ESL_SQFILE *sqfp, int C, int W, ESL_SQ *sq)
  *            expected to be protein - individual sequences won't be long
  *            so read them in one-whole-sequence at a time. If <max_sequences> is set
  *            to a number > 0 read <max_sequences> sequences, up to at most
- *            MAX_RESIDUE_COUNT residues.
+ *            MAX_RESIDUE_COUNT residues. <max_init_window> value is irrelevant
+ *            if <long_target> is false.
  *
  *            If <long_target> is true, the sequences are expected to be DNA.
  *            Because sequences in a DNA database can exceed MAX_RESIDUE_COUNT,
@@ -1421,6 +1422,20 @@ sqascii_ReadWindow(ESL_SQFILE *sqfp, int C, int W, ESL_SQ *sq)
  *            larger than <max_residues>, and must allow for the possibility that a
  *            request will be made to continue reading a partly-read
  *            sequence. This case also respects the <max_sequences> limit.
+ * 
+ *            If <long_target> is true and <max_init_window> is TRUE,
+ *            the first window read from each sequence (of length L)
+ *            is always max(L, <max_residues>). If <max_init_window>
+ *            is FALSE, then the length of the first window read from
+ *            each sequence is calculated differently as 
+ *            max(<max_residues> - <size>, <max_residues> * .05);
+ *            where <size> is total number of residues already existing
+ *            in the block. <max_init_window> == TRUE mode was added
+ *            to ensure that the window boundaries read are not dependent
+ *            on the order of the sequence in the file, thus ensuring
+ *            reproducibility if (for example) a user extracts one
+ *            sequence from a file and reruns a program on it (and all
+ *            else remains equal).
  *
  * Returns:   <eslOK> on success; the new sequence is stored in <sqBlock>.
  * 
@@ -1436,7 +1451,7 @@ sqascii_ReadWindow(ESL_SQFILE *sqfp, int C, int W, ESL_SQ *sq)
  *            <eslEINCONCEIVABLE> on internal error.
  */
 static int
-sqascii_ReadBlock(ESL_SQFILE *sqfp, ESL_SQ_BLOCK *sqBlock, int max_residues, int max_sequences, int long_target)
+sqascii_ReadBlock(ESL_SQFILE *sqfp, ESL_SQ_BLOCK *sqBlock, int max_residues, int max_sequences, int max_init_window, int long_target)
 {
   int     i = 0;
   int     size = 0;
@@ -1523,7 +1538,7 @@ sqascii_ReadBlock(ESL_SQFILE *sqfp, ESL_SQ_BLOCK *sqBlock, int max_residues, int
        * which can result in a window with ~2*max_residues ... or we can end up with absurdly
        * short fragments at the end of blocks
        */
-      int request_size = ESL_MAX(max_residues-size, max_residues * .05);
+      int request_size = (max_init_window) ? max_residues : ESL_MAX(max_residues-size, max_residues * .05);
 
       esl_sq_Reuse(tmpsq);
       esl_sq_Reuse(sqBlock->list + i);

--- a/esl_sqio_ncbi.c
+++ b/esl_sqio_ncbi.c
@@ -1148,7 +1148,7 @@ sqncbi_ReadWindow(ESL_SQFILE *sqfp, int C, int W, ESL_SQ *sq)
  * 
  *            If <long_target> is true and <max_init_window> is TRUE,
  *            the first window read from each sequence (of length L)
- *            is always max(L, <max_residues>). If <max_init_window>
+ *            is always min(L, <max_residues>). If <max_init_window>
  *            is FALSE, then the length of the first window read from
  *            each sequence is calculated differently as 
  *            max(<max_residues> - <size>, <max_residues> * .05);

--- a/esl_sqio_ncbi.c
+++ b/esl_sqio_ncbi.c
@@ -46,7 +46,7 @@ static int   sqncbi_Read           (ESL_SQFILE *sqfp, ESL_SQ *sq);
 static int   sqncbi_ReadInfo       (ESL_SQFILE *sqfp, ESL_SQ *sq);
 static int   sqncbi_ReadSequence   (ESL_SQFILE *sqfp, ESL_SQ *sq);
 static int   sqncbi_ReadWindow     (ESL_SQFILE *sqfp, int C, int W, ESL_SQ *sq);
-static int   sqncbi_ReadBlock      (ESL_SQFILE *sqfp, ESL_SQ_BLOCK *sqBlock, int max_residues, int max_sequences, int long_target);
+static int   sqncbi_ReadBlock      (ESL_SQFILE *sqfp, ESL_SQ_BLOCK *sqBlock, int max_residues, int max_sequences, int max_init_window, int long_target);
 static int   sqncbi_Echo           (ESL_SQFILE *sqfp, const ESL_SQ *sq, FILE *ofp);
 
 static int   sqncbi_IsRewindable   (const ESL_SQFILE *sqfp);
@@ -1144,7 +1144,21 @@ sqncbi_ReadWindow(ESL_SQFILE *sqfp, int C, int W, ESL_SQ *sq)
  *            this function uses ReadWindow to read chunks of sequence no
  *            larger than <max_residues>, and must allow for the possibility that
  *            a request will be made to continue reading a partly-read
- *            sequence.
+ *            sequence. This case also respects the <max_sequences> limit.
+ * 
+ *            If <long_target> is true and <max_init_window> is TRUE,
+ *            the first window read from each sequence (of length L)
+ *            is always max(L, <max_residues>). If <max_init_window>
+ *            is FALSE, then the length of the first window read from
+ *            each sequence is calculated differently as 
+ *            max(<max_residues> - <size>, <max_residues> * .05);
+ *            where <size> is total number of residues already existing
+ *            in the block. <max_init_window> == TRUE mode was added
+ *            to ensure that the window boundaries read are not dependent
+ *            on the order of the sequence in the file, thus ensuring
+ *            reproducibility if (for example) a user extracts one
+ *            sequence from a file and reruns a program on it (and all
+ *            else remains equal).
  *
  * Returns:   <eslOK> on success; the new sequence is stored in <sqBlock>.
  * 
@@ -1158,7 +1172,7 @@ sqncbi_ReadWindow(ESL_SQFILE *sqfp, int C, int W, ESL_SQ *sq)
  *            <eslEINCONCEIVABLE> on internal error.
  */
 static int
-sqncbi_ReadBlock(ESL_SQFILE *sqfp, ESL_SQ_BLOCK *sqBlock, int max_residues, int max_sequences, int long_target)
+sqncbi_ReadBlock(ESL_SQFILE *sqfp, ESL_SQ_BLOCK *sqBlock, int max_residues, int max_sequences, int max_init_window, int long_target)
 {
 	  int     i = 0;
 	  int     size = 0;
@@ -1255,7 +1269,7 @@ sqncbi_ReadBlock(ESL_SQFILE *sqfp, ESL_SQ_BLOCK *sqBlock, int max_residues, int 
 	       * which can result in a window with ~2*max_residues ... or we can end up with absurdly
 	       * short fragments at the end of blocks
 	       */
-		    int request_size = ESL_MAX(max_residues-size, max_residues * .05);
+		    int request_size = (max_init_window) ? max_residues : ESL_MAX(max_residues-size, max_residues * .05);
 
 			  esl_sq_Reuse(tmpsq);
 			  esl_sq_Reuse(sqBlock->list + i);


### PR DESCRIPTION
This pull request accompanies infernal pull request 18 and hmmer
pull request 174. 

This pull request includes support for a new int (effectively boolean)
argument to the esl_sqio_ReadBlock() (both ascii and ncbi versions) of
<max_init_window>. When set to TRUE, this causes the function to
define windows identically for sequences regardless of their order
in a sequence file. Comments from the Purpose: section of the 
esl_sqio_ReadBlock() function:

>   If <long_target> is true and <max_init_window> is TRUE,
>  the first window read from each sequence (of length L)
>  is always min(L, <max_residues>). If <max_init_window>
>  is FALSE, then the length of the first window read from
>  each sequence is calculated differently as 
>  max(<max_residues> - size, <max_residues> * .05);
>  where size is total number of residues already existing
>  in the block. <max_init_window> == TRUE mode was added
>  to ensure that the window boundaries read are not dependent
>  on the order of the sequence in the file, thus ensuring
>  reproducibility if (for example) a user extracts one
>  sequence from a file and reruns a program on it (and all
>  else remains equal).

When <max_init_window> is set to TRUE and (<long_target> is also TRUE)
this reverts behavior to pre-commit 0fadd80 in which Travis added new
code to prevent blocks of possibly 2X <max_residues> length from being
read, which makes threaded implementations more efficient in certain
situations. However, that change also resulted in removing
reproducibility of window definition when sequences are in a different
order. This was reported as a bug in Infernal by Patricia Chan
(tRNAscan-SE developer) who found that cmsearch identified a tRNA hit
(Z) in a sequence file with a single sequence (X) but not in a
sequence file with multiple sequences where sequence X was not the
first sequence. The problem was that windows in X were defined
differently in the two scenarios.

```
File 1 has 2 sequences:
A, length 230218
X, length 813184

File 2 has 1 sequence:
X, length 813184

--
Block definitions using current code (<max_residues> = 100000):
File 1
block 1: sequence A, 1..100000      (100Kb)
block 2: sequence A, 999373..200000  (100Kb)
block 3: sequence A, 199373..230218 (~30Kb)
     and sequence X, 1..69782       (~70Kb)
(remainder of blocks irrelevant)

File 2
block 1: sequence X, 1..100000      (100Kb)
(remainder of blocks irrelevant)

Note that the first window of sequence X differs depending on which
which file is being read using current code.
--
Block definitions using new pull request code and <max_init_window> set to TRUE (same behavior as pre- 0fadd80 code):

File 1
block 1: sequence A, 1..100000      (100Kb)
block 2: sequence A, 999373..200000  (100Kb)
block 3: sequence A, 199373..230218 (~30Kb)
     and sequence X, 1..100000      (100Kb)

File 2
block 1: sequence X, 1..100000      (100Kb)
(remainder of blocks irrelevant)

Note that the first window of sequence X is identical for both files using pull request code.
```

This is a problem because hits can be filtered out or not depending on the window they are in.
