### PR TITLE
esl_sqio_ascii rare bug: final record line longer than all previous does not invalidate fast subseq retrieval

### DIFF
--- a/esl_sqio_ascii.c
+++ b/esl_sqio_ascii.c
@@ -2274,13 +2274,15 @@ seebuf(ESL_SQFILE *sqfp, int64_t maxn, int64_t *opt_nres, int64_t *opt_endpos)
          if (ascii->currpl != -1) ascii->currpl += nres - nres2;
          nres2        += nres - nres2;
 
-         if (ascii->rpl != 0 && ascii->prvrpl != -1) { /* need to ignore counts on last line in record, hence cur/prv */
-           if      (ascii->rpl    == -1)        ascii->rpl = ascii->prvrpl; /* init */
-           else if (ascii->prvrpl != ascii->rpl) ascii->rpl = 0;           /* inval*/
+         if (ascii->rpl != 0 && ascii->prvrpl != -1) { /* need to treat counts on last line in record differently (can be shorter but not longer), hence cur/prv */
+           if      (ascii->rpl    == -1)         ascii->rpl = ascii->prvrpl; /* init  */
+           else if (ascii->prvrpl != ascii->rpl) ascii->rpl = 0;             /* inval */
+           else if (ascii->currpl  > ascii->rpl) ascii->rpl = 0;             /* inval, this covers case when final line is longer */
          }
          if (ascii->bpl != 0 && ascii->prvbpl != -1) {
-           if      (ascii->bpl    == -1)        ascii->bpl = ascii->prvbpl; /* init  */
-           else if (ascii->prvbpl != ascii->bpl) ascii->bpl = 0;            /* inval */
+           if      (ascii->bpl    == -1)         ascii->bpl = ascii->prvbpl; /* init  */
+           else if (ascii->prvbpl != ascii->bpl) ascii->bpl = 0;             /* inval */
+           else if (ascii->curbpl  > ascii->bpl) ascii->bpl = 0;             /* inval, this covers case when final line is longer */
          }
 
          ascii->prvbpl  = ascii->curbpl;


### PR DESCRIPTION
If a sequence file has a record that has equal bytes/residues on each
line except for the final one, then it will be flagged for fast
subsequence retrieval. This is by design because the final line can
be, and usually is, shorter than all the rest, but if the final line has
more characters than all previous lines it can lead to a
problem. Specifically if you try to fetch a subseq for which all
nucleotides occur past the final rpl'th character of the final line
for that record, you get an error.

I propose a fix to not flag such sequence files for fast subsequence
retrieval if the final line has greater than rpl/bpl residues/bytes. 

Admittedly I'm not sure of all the impacts of this change, since
seebuf() is so central, but the tests all pass, and the change
does look innocuous to me.

Example files to reproduce (I had to add the .txt suffices to enable upload...)

[ok.fa.txt](https://github.com/EddyRivasLab/easel/files/4884658/ok.fa.txt):
sequence file with 11 nt sequence AAACCCGGGGG named 'seq' with
3 nt on line 1 and 4 on lines 2 and 3.

[bug.fa.txt](https://github.com/EddyRivasLab/easel/files/4884660/bug.fa.txt):
sequence file with same sequence as ok.fa with 3 nt on lines 1
and 2 and 5 on line 3.

[repro.sh.txt](https://github.com/EddyRivasLab/easel/files/4884652/repro.sh.txt):
script to reproduce the problem that indexes ok.fa and
bug.fa and then tries to fetch the subsequence 11..11. This works for
ok.fa but throws an error for bug.fa, demonstrating the bug.
