### PR TITLE
Fix ReadBlock()'s handling of "//" delimiter in embl files

### DIFF
--- a/esl_sqio_ascii.c
+++ b/esl_sqio_ascii.c
@@ -1559,7 +1559,7 @@ sqascii_ReadBlock(ESL_SQFILE *sqfp, ESL_SQ_BLOCK *sqBlock, int max_residues, int
         status = skip_whitespace(sqfp);
         if ( status != eslOK ) { // either EOD or end of buffer (EOF) was reached before the next character was seen
           sqBlock->complete = TRUE;
-          status = eslOK;
+          status = sqfp->data.ascii.parse_end(sqfp, sqBlock->list+i);
         }
 
         if(tmpsq != NULL) esl_sq_Destroy(tmpsq);


### PR DESCRIPTION
This PR is in conjunction with HMMER PR https://github.com/EddyRivasLab/hmmer/pull/200, and is thus associated with issue https://github.com/EddyRivasLab/hmmer/issues/195

When provided with a multi-block embl file, nhmmer's multithreaded ReadBlock-based sequence reader would fail when starting to read the second block, because the reader failed to skip past the "//" conclusion of the final sequence of the first block. Fixed here.  
