### PR TITLE
Fix hmmer make check after configure --with-gsl

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -67,7 +67,7 @@ VMX_CFLAGS     = @VMX_CFLAGS@
 CPPFLAGS       = @CPPFLAGS@
 LDFLAGS        = @LDFLAGS@
 LIBGSL         = @LIBGSL@
-LIBS           = @LIBS@ @PTHREAD_LIBS@
+LIBS           = @LIBS@ @PTHREAD_LIBS@ @LIBGSL@
 
 
 # Other tools


### PR DESCRIPTION
When configuring and building hmmer 3.3.1 using the option `--with-gsl` i.e. `./configure --with-gsl`, `make check` fails to complete as the relevant (`-lgsl -lgslcblas`) libs are not included. This can be seen [here](https://github.com/kiwiroy/hmmer-test/runs/1214104041?check_suite_focus=true#step:4:440), a result of the [workflow file](https://github.com/kiwiroy/hmmer-test/blob/master/.github/workflows/hmmer.yml) for the action.

With the patch from this pull request [applied](https://github.com/kiwiroy/hmmer-test/blob/master/.github/workflows/hmmer-fix.yml) the resultant action and `make check` [succeeds](https://github.com/kiwiroy/hmmer-test/runs/1214104043?check_suite_focus=true#step:4:963).
