### PR TITLE
Fix unitialized `abc` pointer in `ESL_SQ` struct

### DIFF
--- a/esl_sq.c
+++ b/esl_sq.c
@@ -2186,8 +2186,15 @@ sq_init(ESL_SQ *sq, int do_digital)
   ESL_ALLOC(sq->acc,    sizeof(char) * sq->aalloc);
   ESL_ALLOC(sq->desc,   sizeof(char) * sq->dalloc);
   ESL_ALLOC(sq->source, sizeof(char) * sq->srcalloc);
-  if (do_digital) ESL_ALLOC(sq->dsq,  sizeof(ESL_DSQ) * sq->salloc);
-  else            ESL_ALLOC(sq->seq,  sizeof(char)    * sq->salloc);
+  if (do_digital)
+    {
+      ESL_ALLOC(sq->dsq,  sizeof(ESL_DSQ) * sq->salloc);
+    }
+  else 
+    {
+      ESL_ALLOC(sq->seq,  sizeof(char)    * sq->salloc);
+      sq->abc = NULL;
+    }
 
   esl_sq_Reuse(sq);	/* initialization of sq->n, offsets, and strings */
   return eslOK;


### PR DESCRIPTION
Hi!

This PR fixes an uninitialized pointer in the `ESL_SQ` struct initializer. Since the `sq->abc` was not set to NULL here, there was a risk that this field would contain garbage later on. I discovered this when calling `esl_sq_Compare` on two sequences in text mode: I would get a segmentation fault since the `abc` pointer would not be `NULL` (because of some garbage in the allocated memory) and it would then try to compare the alphabets, interpreting the garbage as pointers.

_A bit of context (and a shameless plug): I discovered this while writing `pyhmmer`, a Cython extension module that provides Python bindings to HMMER and Easel (it's on [GitHub](https://github.com/althonos/pyhmmer) and on [PyPI](https://pypi.org/project/pyhmmer))._

