### PR TITLE
Add horizontal sum of float32x4 NEON vector

### DIFF
--- a/esl_neon.c
+++ b/esl_neon.c
@@ -571,6 +571,27 @@ utest_hmax_s16(ESL_RANDOMNESS *rng)
 }
 
 
+static void
+utest_hmax_f32(ESL_RANDOMNESS *rng)
+{
+  union { esl_neon_128f_t v; float x[4]; } u;
+  float r1, r2;
+  int   i,z;
+
+  for (i = 0; i < 100; i++)
+    {
+      r1 = 0;
+      for (z = 0; z < 4; z++)
+        {
+          u.x[z] = (float) esl_random(rng);
+          if (u.x[z] > r1) r1 = u.x[z];
+        }
+      r2 = esl_neon_hmax_f32(u.v);
+      if (r1 != r2) esl_fatal("hmax_f32 utest failed: %f != %f", r1, r2);
+    }
+}
+
+
 #endif /*eslNEON_TESTDRIVE*/
 
 
@@ -625,6 +646,7 @@ main(int argc, char **argv)
   utest_hmax_u8(rng);
   utest_hmax_s8(rng);
   utest_hmax_s16(rng);
+  utest_hmax_f32(rng);
 
   fprintf(stderr, "#  status   = ok\n");
 

--- a/esl_neon.h
+++ b/esl_neon.h
@@ -198,6 +198,21 @@ esl_neon_hmax_s16(esl_neon_128i_t a)
 #endif
 }
 
+/* Function:  esl_neon_hmax_f32()
+ * Synopsis:  Return max of 4 elements in f32 vector.
+ */
+static inline float
+esl_neon_hmax_f32(esl_neon_128f_t a)
+{
+  #ifdef eslHAVE_NEON_AARCH64
+    return vmaxvq_f32(a.f32x4);
+  #else
+    float32x2_t tmp;
+    tmp = vpmax_f32(vget_low_f32(a.f32x4), vget_high_f32(a.f32x4));
+    tmp = vpmax_f32(tmp, tmp);
+    return vget_lane_f32(tmp, 1);
+  #endif
+}
 
 /* Function:  esl_neon_hsum_float()
  * Synopsis:  Takes the horizontal sum of elements in a vector.


### PR DESCRIPTION
Hi!

I started porting HMMER to the Aarch64 platform ([althonos/hmmer-neon](https://github.com/althonos/hmmer-neon)), and while doing so (using the SSE code as a reference) I noticed Easel was missing this function. Its SSE counterpart (`esl_sse_hmax_ps`) is used in the Viterbi score implementation.

This PR adds the `esl_neon_hmax_f32` function, using either:
* the `vmaxvq_f32` instruction in Aarch64
* a folding algorithm using `vpmax_f32` in Armv7

Both functions were tested on a Raspberry Pi 4.