### PR TITLE
Use intrinsic for `esl_sse_select_ps` if compiling for SSE4

### DIFF
--- a/esl_sse.h
+++ b/esl_sse.h
@@ -310,9 +310,13 @@ esl_sse_any_gt_ps(__m128 a, __m128 b)
 static inline __m128
 esl_sse_select_ps(__m128 a, __m128 b, __m128 mask)
 {
+#ifdef eslENABLE_SSE4
+  return _mm_blendv_ps(a, b, mask);
+#else
   b = _mm_and_ps(b, mask);
   a = _mm_andnot_ps(mask, a);
   return _mm_or_ps(a,b);
+#endif
 }
 
 


### PR DESCRIPTION
Hi!

`esl_sse_select_ps` has an equivalent intrinsic available in SSE4.1, with double the throughput (2/3 cycles for the SSE4 version with 1 instruction, 3 cycles for the SSE version using 3 instructions), so it can be used when Easel is compiled with SSE4 support. I added a unit test to make sure both version work the same.
