### PR TITLE
 Fix inconsistent `esl_sqfile_GuessAlphabet` behaviour on file with empty sequences

### DIFF
--- a/esl_sqio.c
+++ b/esl_sqio.c
@@ -2176,6 +2176,9 @@ utest_guess_mechanics(ESL_ALPHABET *abc, ESL_SQ **sqarr, int N)
  * Make sure that esl_sqfile_GuessAlphabet() returns eslNOALPHABET when
  * it tries to guess the alphabet on files containing only empty sequences.
  *
+ * Related to bugfix 441a4d3: sqascii_GuessAlphabet() did not handle
+ * the case where sqascii_ReadWindow() would return eslEOD on empty
+ * sequences, and returned an error instead of eslENOALPHABET.
  */
 static void
 utest_guess_empty_seq()
@@ -2202,8 +2205,8 @@ utest_guess_empty_seq()
   esl_sqfile_Close(sqfp);
   remove(tmpfile);
 
-  free(seqs[0]);
-  free(seqs[1]);
+  esl_sq_Destroy(seqs[0]);
+  esl_sq_Destroy(seqs[1]);
 }
 
 #endif /*eslSQIO_TESTDRIVE*/

--- a/esl_sqio.c
+++ b/esl_sqio.c
@@ -2170,6 +2170,42 @@ utest_guess_mechanics(ESL_ALPHABET *abc, ESL_SQ **sqarr, int N)
     }
 }
 
+/* utest_guess_empty_seq()
+ * ML, 9 Oct 21
+ *
+ * Make sure that esl_sqfile_GuessAlphabet() returns eslNOALPHABET when
+ * it tries to guess the alphabet on files containing only empty sequences.
+ *
+ */
+static void
+utest_guess_empty_seq()
+{
+  char       *msg         = "sqio guess_empty_seq unit test failure";
+  char        tmpfile[32];
+  ESL_SQ*     seqs[2];
+  FILE       *fp;
+  ESL_SQFILE *sqfp;
+  int         i;
+  int         alphatype;
+
+  if ((seqs[0] = esl_sq_CreateFrom("seqs0", "", NULL, NULL, NULL)) == NULL) esl_fatal(msg);
+  if ((seqs[1] = esl_sq_CreateFrom("seqs1", "", NULL, NULL, NULL)) == NULL) esl_fatal(msg);
+
+  strcpy(tmpfile, "esltmpXXXXXX");
+  if (esl_tmpfile_named(tmpfile, &fp)                     != eslOK) esl_fatal(msg);
+  if (esl_sqio_Write(fp, seqs[0], eslSQFILE_FASTA, FALSE) != eslOK) esl_fatal(msg);
+  if (esl_sqio_Write(fp, seqs[1], eslSQFILE_FASTA, FALSE) != eslOK) esl_fatal(msg);
+  fclose(fp);
+
+  if (esl_sqfile_Open(tmpfile, eslSQFILE_FASTA, NULL, &sqfp) != eslOK) esl_fatal(msg);
+  if (esl_sqfile_GuessAlphabet(sqfp, &alphatype) != eslENOALPHABET)    esl_fatal(msg);
+  esl_sqfile_Close(sqfp);
+  remove(tmpfile);
+
+  free(seqs[0]);
+  free(seqs[1]);
+}
+
 #endif /*eslSQIO_TESTDRIVE*/
 /*------------------ end, unit tests ----------------------------*/
 
@@ -2260,6 +2296,7 @@ main(int argc, char **argv)
 
   utest_guess_mechanics(abc, sqarr, N);
   utest_write          (abc, sqarr, N, eslMSAFILE_STOCKHOLM);
+  utest_guess_empty_seq();
 
   for (i = 0; i < N; i++) esl_sq_Destroy(sqarr[i]);
   free(sqarr);

--- a/esl_sqio_ascii.c
+++ b/esl_sqio_ascii.c
@@ -657,8 +657,8 @@ sqascii_GuessAlphabet(ESL_SQFILE *sqfp, int *ret_type)
   if ((sq = esl_sq_Create()) == NULL) { status = eslEMEM; goto ERROR; }
 
   status = sqascii_ReadWindow(sqfp, 0, 4000, sq);
-  if      (status == eslEOF) { status = eslENODATA; goto ERROR; }
-  else if (status != eslOK)  goto ERROR; 
+  if      ((status == eslEOF)) { status = eslENODATA; goto ERROR; }
+  else if ((status != eslOK) && (status != eslEOD))  goto ERROR;
 
   if ((status = esl_sq_GuessAlphabet(sq, ret_type)) != eslOK) goto ERROR;
 

--- a/esl_sqio_ascii.c
+++ b/esl_sqio_ascii.c
@@ -657,8 +657,8 @@ sqascii_GuessAlphabet(ESL_SQFILE *sqfp, int *ret_type)
   if ((sq = esl_sq_Create()) == NULL) { status = eslEMEM; goto ERROR; }
 
   status = sqascii_ReadWindow(sqfp, 0, 4000, sq);
-  if      ((status == eslEOF)) { status = eslENODATA; goto ERROR; }
-  else if ((status != eslOK) && (status != eslEOD))  goto ERROR;
+  if      (status == eslEOF) { status = eslENODATA; goto ERROR; }
+  else if ((status != eslOK) && (status != eslEOD)) goto ERROR;
 
   if ((status = esl_sq_GuessAlphabet(sq, ret_type)) != eslOK) goto ERROR;
 


### PR DESCRIPTION
Hi!

`esl_sqfile_GuessAlphabet` is supposed to return `eslNOALPHABET` when it cannot guess the alphabet of a sequence file. On files containing only empty sequences, this would be the expected return code. However when writing unit tests for [`pyhmmer`](https://github.com/althonos/pyhmmer) I noticed that it would unexpectedly return `eslEOD` instead.

Turns out `sqascii_GuessAlphabet` calls `sqascii_ReadWindow`, which can return `eslEOD` when it reaches the end of a sequence, but that case was not handled properly:
```c
  status = sqascii_ReadWindow(sqfp, 0, 4000, sq);
  if      ((status == eslEOF)) { status = eslENODATA; goto ERROR; }
  else if (status != eslOK)  goto ERROR;
```

This PR adds a unit test to make sure `eslNOALPHABET` is returned on files with empty sequences, and replaces the code above with:
```c
  status = sqascii_ReadWindow(sqfp, 0, 4000, sq);
  if      ((status == eslEOF)) { status = eslENODATA; goto ERROR; }
  else if ((status != eslOK) && (status != eslEOD))  goto ERROR;
```
to make sure that `eslEOD` is not considered an error here. 