### PR TITLE
Add some compatibility code for compiling with MinGW

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ Makefile
 /autom4te.cache
 /build-*/
 *.o
+*.exe
 *.dSYM
 easel_utest
 easel_example

--- a/configure.ac
+++ b/configure.ac
@@ -543,6 +543,7 @@ AC_SEARCH_LIBS(socket,    socket)
 AC_SEARCH_LIBS(inet_pton, nsl)
 
 AC_FUNC_FSEEKO
+AC_FUNC_MMAP
 
 #################################################################
 # 12. System services

--- a/configure.ac
+++ b/configure.ac
@@ -443,7 +443,8 @@ AC_CHECK_HEADERS([\
   strings.h   \
   unistd.h    \
   sys/types.h \
-  netinet/in.h
+  netinet/in.h \
+  syslog.h
 ])
 
 # Check for sysctl.h separately.  On OpenBSD, it requires
@@ -523,6 +524,7 @@ AC_CHECK_FUNCS([ \
   aligned_alloc  \
   erfc           \
   getpid         \
+  getppid        \
   _mm_malloc     \
   popen          \
   posix_memalign \

--- a/configure.ac
+++ b/configure.ac
@@ -532,6 +532,8 @@ AC_CHECK_FUNCS([ \
   _mm_malloc     \
   popen          \
   posix_memalign \
+  _putenv_s      \
+  setenv         \
   strcasecmp     \
   strsep         \
   sysconf        \

--- a/configure.ac
+++ b/configure.ac
@@ -437,14 +437,14 @@ AC_SEARCH_LIBS(clock_gettime, [rt posix4])
 ################################################################
 
 AC_CHECK_HEADERS([\
-  endian.h    \
-  inttypes.h  \
-  stdint.h    \
-  strings.h   \
-  unistd.h    \
-  sys/types.h \
+  endian.h     \
+  inttypes.h   \
+  stdint.h     \
+  strings.h    \
+  unistd.h     \
+  sys/types.h  \
   netinet/in.h \
-  syslog.h
+  syslog.h     \
 ])
 
 # Check for sysctl.h separately.  On OpenBSD, it requires
@@ -482,7 +482,10 @@ AC_TYPE_OFF_T
 ################################################################
 # 9. Checks for structures - currently none
 #################################################################
-
+#    - Make sure that the stat struct has an st_blksize field
+#      that can be used in `esl_buffer.c` to get the block size
+#
+AC_CHECK_MEMBERS([struct stat.st_blksize])
 
 ################################################################
 # 10. Checks for compiler characteristics

--- a/configure.ac
+++ b/configure.ac
@@ -174,6 +174,7 @@ AC_ARG_ENABLE(avx512,  [AS_HELP_STRING([--enable-avx512],  [enable our AVX-512 v
 AC_ARG_ENABLE(neon,    [AS_HELP_STRING([--enable-neon],    [enable our NEON vector code])] ,            enable_neon=$enableval,    enable_neon=check)
 AC_ARG_ENABLE(vmx,     [AS_HELP_STRING([--enable-vmx],     [enable our Altivec/VMX vector code])],      enable_vmx=$enableval,     enable_vmx=check)
 
+AC_ARG_ENABLE(gzip,    [AS_HELP_STRING([--enable-gzip],    [enable reading Gzip compressed files])],    enable_gzip=$enableval,    enable_gzip=yes)
 AC_ARG_ENABLE(threads, [AS_HELP_STRING([--enable-threads], [enable POSIX threads parallelization])],    enable_threads=$enableval, enable_threads=check)
 AC_ARG_ENABLE(mpi,     [AS_HELP_STRING([--enable-mpi],     [enable MPI parallelization])],              enable_mpi=$enableval,     enable_mpi=no)
 
@@ -391,16 +392,10 @@ AC_COMPILE_IFELSE(
 
 CFLAGS="$esl_save_cflags"
 
-
-
-# Define HAVE_GZIP if gzip is in $PATH (or if HAVE_GZIP is already set)
-AC_PATH_PROG(HAVE_GZIP, "gzip", "no")
-if test "${HAVE_GZIP}" = "no"; then
-  AC_MSG_WARN([gzip not found])
-else
+# Define HAVE_GZIP unless --disable-gzip was given to the configure script
+AS_IF([test "x$enable_gzip" != xno],
   AC_DEFINE([HAVE_GZIP],1,[Support external gzip decompression])
-fi
-
+)
 
 # We need python 3 for 'make check' and some dev tools. sqc checks
 # too, as does the Makefile, but we also check in ./configure, so we

--- a/configure.ac
+++ b/configure.ac
@@ -523,6 +523,7 @@ AX_GCC_FUNC_ATTRIBUTE(format)
 AC_CHECK_FUNCS([ \
   aligned_alloc  \
   erfc           \
+  fstat          \
   getpid         \
   getppid        \
   _mm_malloc     \

--- a/easel.c
+++ b/easel.c
@@ -2123,15 +2123,25 @@ esl_tmpfile(char *basename6X, FILE **ret_fp)
   int   status;
   mode_t old_mode;
 
+
   /* Determine what tmp directory to use, and construct the
    * file name.
    */
+#if defined(__MINGW32__) || defined(__CYGWIN__)
+  /* this is sufficient to detect Windows, however we may want
+   * to use the "fileapi.h" function `GetTempPath2A` instead to
+   * get the system-defined temporary file path.
+   */
+  tmpdir = getenv("TEMP");
+  if (tmpdir == NULL) tmpdir = "C:\\Windows\\Temp";
+#else
   if (getuid() == geteuid() && getgid() == getegid()) 
     {
       tmpdir = getenv("TMPDIR");
       if (tmpdir == NULL) tmpdir = getenv("TMP");
     }
   if (tmpdir == NULL) tmpdir = "/tmp";
+#endif
   if ((status = esl_FileConcat(tmpdir, basename6X, &path)) != eslOK) goto ERROR; 
 
   old_mode = umask(077);

--- a/easel.c
+++ b/easel.c
@@ -2231,7 +2231,7 @@ esl_tmpfile_named(char *basename6X, FILE **ret_fp)
   *ret_fp = NULL;
 #ifdef __MINGW32__
   char* path;
-  if ((path = _mktemp(basename6X)) == NULL)                                             return eslFAIL;
+  if ((path = _mktemp(basename6X)) == NULL)                              return eslFAIL;
   if ((fd = _open(path,  _O_CREAT | _O_RDWR, _S_IREAD | _S_IWRITE)) < 0) return eslFAIL;
 #else
   old_mode = umask(077);

--- a/easel.c
+++ b/easel.c
@@ -2229,9 +2229,15 @@ esl_tmpfile_named(char *basename6X, FILE **ret_fp)
   int    fd;
 
   *ret_fp = NULL;
+#ifdef __MINGW32__
+  char* path;
+  if ((path = _mktemp(basename6X)) == NULL)                                             return eslFAIL;
+  if ((fd = _open(path,  _O_CREAT | _O_RDWR, _S_IREAD | _S_IWRITE)) < 0) return eslFAIL;
+#else
   old_mode = umask(077);
   if ((fd = mkstemp(basename6X)) <  0)  return eslFAIL;
   umask(old_mode);
+#endif
   if ((fp = fdopen(fd, "w+b")) == NULL) return eslFAIL;
 
   *ret_fp = fp;

--- a/easel.h
+++ b/easel.h
@@ -408,7 +408,11 @@ typedef uint8_t ESL_DSQ;
  *
  * This gets used in easel.c's *_File*() functions.
  */
+#ifdef __MINGW32__
+#define eslDIRSLASH '\\'          /* Windows directory paths have C:\foo\bar */
+#else
 #define eslDIRSLASH '/'           /* UNIX directory paths have /foo/bar */
+#endif
 
 /* Some generic macros for swapping, min, and max.
  */

--- a/esl_buffer.c
+++ b/esl_buffer.c
@@ -2770,6 +2770,7 @@ utest_halfnewline(void)
   esl_pos_t   n     = 0;  
   int         status;
   
+#ifdef SIGALRM
   signal(SIGALRM, alarm_handler); // the bug is an infinite loop in esl_buffer_GetLine(), so we use an alarm signal to trap it.
   alarm(1);                       // this utest will self destruct in one second...
 
@@ -2784,6 +2785,7 @@ utest_halfnewline(void)
   esl_buffer_Close(bf);
   alarm(0);                  // removes self-destruct alarm
   signal(SIGALRM, SIG_DFL);  // deletes self-destruct handler
+#endif
   return;
 }
        

--- a/esl_buffer.c
+++ b/esl_buffer.c
@@ -214,7 +214,7 @@ esl_buffer_OpenFile(const char *filename, ESL_BUFFER **ret_bf)
    * If we don't have fstat(), we'll just read normally, and pagesize
    * will be the Easel default 4096 (set in buffer_create().)
    */
-#ifdef _POSIX_VERSION
+#ifdef HAVE_FSTAT
   if (fstat(fileno(bf->fp), &fileinfo) == -1) ESL_XEXCEPTION(eslESYS, "fstat() failed");
   filesize     = fileinfo.st_size;
   bf->pagesize = fileinfo.st_blksize;

--- a/esl_config.h.in
+++ b/esl_config.h.in
@@ -89,6 +89,8 @@
 #undef HAVE_MMAP            // esl_buffer
 #undef HAVE_POPEN           // various file parsers that check for piped input
 #undef HAVE_POSIX_MEMALIGN  // esl_alloc
+#undef HAVE__PUTENV_S       // esl_getopts utest
+#undef HAVE_SETENV          // esl_getopts utest
 #undef HAVE_STRCASECMP      // easel::esl_strcasecmp()
 #undef HAVE_STRSEP          // easel::esl_strsep()
 #undef HAVE_SYSCONF         // esl_threads, asking system for cpu number

--- a/esl_config.h.in
+++ b/esl_config.h.in
@@ -80,8 +80,9 @@
 #undef HAVE_ERFC            // esl_stats
 #undef HAVE_GETCWD          // esl_getcwd
 #undef HAVE_GETPID          // esl_random
-#undef HAVE_GETPPID         // esl_fail
+#undef HAVE_GETPPID         // easel::esl_fail()
 #undef HAVE__MM_MALLOC      // esl_alloc
+#undef HAVE_MMAP            // esl_buffer
 #undef HAVE_POPEN           // various file parsers that check for piped input
 #undef HAVE_POSIX_MEMALIGN  // esl_alloc
 #undef HAVE_STRCASECMP      // easel::esl_strcasecmp()

--- a/esl_config.h.in
+++ b/esl_config.h.in
@@ -71,6 +71,9 @@
 #undef uint64_t
 #undef off_t
 
+/* Structures */
+#undef HAVE_STRUCT_STAT_ST_BLKSIZE
+
 /* Compiler characteristics */
 #undef HAVE_FUNC_ATTRIBUTE_NORETURN // Compiler supports __attribute__((__noreturn__)), helps w/ clang static analysis.
 #undef HAVE_FUNC_ATTRIBUTE_FORMAT   // Compiler supports __attribute__((format(a,b,c))), typechecking printf-like functions

--- a/esl_config.h.in
+++ b/esl_config.h.in
@@ -54,6 +54,7 @@
 #undef HAVE_SYS_TYPES_H
 #undef HAVE_STRINGS_H
 #undef HAVE_NETINET_IN_H	/* On FreeBSD, you need netinet/in.h for struct sockaddr_in */
+#undef HAVE_SYSLOG_H
 
 #undef HAVE_SYS_PARAM_H
 #undef HAVE_SYS_SYSCTL_H
@@ -79,6 +80,7 @@
 #undef HAVE_ERFC            // esl_stats
 #undef HAVE_GETCWD          // esl_getcwd
 #undef HAVE_GETPID          // esl_random
+#undef HAVE_GETPPID         // esl_fail
 #undef HAVE__MM_MALLOC      // esl_alloc
 #undef HAVE_POPEN           // various file parsers that check for piped input
 #undef HAVE_POSIX_MEMALIGN  // esl_alloc

--- a/esl_config.h.in
+++ b/esl_config.h.in
@@ -78,6 +78,7 @@
 /* Functions */
 #undef HAVE_ALIGNED_ALLOC   // esl_alloc
 #undef HAVE_ERFC            // esl_stats
+#undef HAVE_FSTAT           // esl_buffer
 #undef HAVE_GETCWD          // esl_getcwd
 #undef HAVE_GETPID          // esl_random
 #undef HAVE_GETPPID         // easel::esl_fail()

--- a/esl_getopts.c
+++ b/esl_getopts.c
@@ -1964,8 +1964,15 @@ main(void)
   /* Put some test vars in the environment.
    * (Note: apparently, on some OS's (Mac OS/X), setenv() necessarily leaks memory.)
    */
+#ifdef HAVE_SETENV
   setenv("FOOTEST",  "",                         1);
   setenv("HOSTTEST", "wasp.cryptogenomicon.org", 1);
+#else
+#ifdef HAVE__PUTENV_S
+  _putenv_s("FOOTEST",  ""                        );
+  _putenv_s("HOSTTEST", "wasp.cryptogenomicon.org");
+#endif
+#endif
 
   /* Open the test config files for reading.
    */

--- a/esl_msafile.c
+++ b/esl_msafile.c
@@ -593,7 +593,7 @@ esl_msafile_GuessFileFormat(ESL_BUFFER *bf, int *ret_fmtcode, ESL_MSAFILE_FMTDAT
   /* Skip blank lines, get first non-blank one */
   do   { 
     status = esl_buffer_GetLine(bf, &p, &n);
-  } while (status == eslOK && esl_memspn(p, n, " \t") == n);
+  } while (status == eslOK && esl_memspn(p, n, " \t\r") == n);
   if (status == eslEOF) ESL_XFAIL(eslENOFORMAT, errbuf, "can't guess alignment input format: empty file/no data");
 
   if      (esl_memstrpfx(p, n, "# STOCKHOLM"))                      fmt_byfirstline = eslMSAFILE_STOCKHOLM;
@@ -604,8 +604,8 @@ esl_msafile_GuessFileFormat(ESL_BUFFER *bf, int *ret_fmtcode, ESL_MSAFILE_FMTDAT
     char     *tok;
     esl_pos_t toklen;
     /* look for <nseq> <alen>, characteristic of PHYLIP files */
-    if (esl_memtok(&p, &n, " \t", &tok, &toklen) == eslOK  && esl_memspn(tok, toklen, "0123456789") == toklen &&
-	esl_memtok(&p, &n, " \t", &tok, &toklen) == eslOK  && esl_memspn(tok, toklen, "0123456789") == toklen)
+    if (esl_memtok(&p, &n, " \t\r", &tok, &toklen) == eslOK  && esl_memspn(tok, toklen, "0123456789") == toklen &&
+	esl_memtok(&p, &n, " \t\r", &tok, &toklen) == eslOK  && esl_memspn(tok, toklen, "0123456789") == toklen)
       fmt_byfirstline = eslMSAFILE_PHYLIP; /* interleaved for now; we'll look more closely soon */
   }
 
@@ -813,7 +813,7 @@ msafile_check_selex(ESL_BUFFER *bf)
       if (esl_memstrpfx(p, n, "#"))    continue;
       
       /* blank lines: end block, reset block counters */
-      if (esl_memspn(p, n, " \t") == n)
+      if (esl_memspn(p, n, " \t\r") == n)
 	{
 	  if (block_nseq && block_nseq != nseq) { status = eslFAIL; goto DONE;} /* each block has same # of seqs */
 	  if (in_block) blockidx++;
@@ -830,16 +830,16 @@ msafile_check_selex(ESL_BUFFER *bf)
        * starts with the same seq name..
        */
       in_block = TRUE;
-      if ( (status = esl_memtok(&p, &n, " \t", &tok, &toklen)) != eslOK) goto ERROR; /* there's at least one token - we already checked for blank lines */
+      if ( (status = esl_memtok(&p, &n, " \t\r", &tok, &toklen)) != eslOK) goto ERROR; /* there's at least one token - we already checked for blank lines */
       if (nseq == 0)	/* check first seq name in each block */
 	{
 	  if (blockidx == 0) { firstname = tok; namelen = toklen; } /* First block: set the name we check against. */
 	  else if (toklen != namelen || memcmp(tok, firstname, toklen) != 0) { status = eslFAIL; goto DONE; } /* Subsequent blocks */
 	}
-      if (esl_memtok(&p, &n, " \t", &tok, &toklen) != eslOK) { status = eslFAIL; goto DONE; }
+      if (esl_memtok(&p, &n, " \t\r", &tok, &toklen) != eslOK) { status = eslFAIL; goto DONE; }
       if (block_nres && toklen != block_nres)                { status = eslFAIL; goto DONE; }
       block_nres = toklen;
-      if (esl_memtok(&p, &n, " \t", &tok, &toklen) == eslOK) { status = eslFAIL; goto DONE; }
+      if (esl_memtok(&p, &n, " \t\r", &tok, &toklen) == eslOK) { status = eslFAIL; goto DONE; }
       nseq++;
     }
   if (status != eslEOF) goto ERROR;  /* EOF is expected and good; anything else is bad */

--- a/esl_msafile_afa.c
+++ b/esl_msafile_afa.c
@@ -34,7 +34,8 @@
  *            Digital mode enforces the usual Easel alphabets.
  * 
  *            We skip spaces in input lines of aligned FASTA format;
- *            map ' ' to <eslDSQ_IGNORED>.
+ *            map ' ' to <eslDSQ_IGNORED>. For Windows compatibility,
+ *            carriage returns are ignored; map '\r' to <eslDSQ_IGNORED>.
  */
 int
 esl_msafile_afa_SetInmap(ESL_MSAFILE *afp)
@@ -55,7 +56,8 @@ esl_msafile_afa_SetInmap(ESL_MSAFILE *afp)
       afp->inmap[0]   = '?';
     }
 
-  afp->inmap[' '] = eslDSQ_IGNORED;
+  afp->inmap[' ']  = eslDSQ_IGNORED;
+  afp->inmap['\r'] = eslDSQ_IGNORED;
   return eslOK;
 }
 
@@ -197,7 +199,7 @@ esl_msafile_afa_Read(ESL_MSAFILE *afp, ESL_MSA **ret_msa)
   if (! afp->abc &&  (msa = esl_msa_Create(                 16, -1)) == NULL) { status = eslEMEM; goto ERROR; }
   
   /* skip leading blank lines in file */
-  while ( (status = esl_msafile_GetLine(afp, &p, &n)) == eslOK && esl_memspn(afp->line, afp->n, " \t") == afp->n) ;
+  while ( (status = esl_msafile_GetLine(afp, &p, &n)) == eslOK && esl_memspn(afp->line, afp->n, " \t\r") == afp->n) ;
   if      (status != eslOK)  goto ERROR; /* includes normal EOF */
 
   /* tolerate sloppy space at start of line */
@@ -208,7 +210,7 @@ esl_msafile_afa_Read(ESL_MSAFILE *afp, ESL_MSA **ret_msa)
     if (n <= 1 || *p != '>' ) ESL_XFAIL(eslEFORMAT, afp->errmsg, "expected aligned FASTA name/desc line starting with >");    
     p++; n--;			/* advance past > */
 
-    if ( (status = esl_memtok(&p, &n, " \t", &tok, &ntok)) != eslOK) ESL_XFAIL(eslEFORMAT, afp->errmsg, "no name found for aligned FASTA record");
+    if ( (status = esl_memtok(&p, &n, " \t\r", &tok, &ntok)) != eslOK) ESL_XFAIL(eslEFORMAT, afp->errmsg, "no name found for aligned FASTA record");
     if (idx >= msa->sqalloc && (status = esl_msa_Expand(msa))    != eslOK) goto ERROR;
 
     if (     (status = esl_msa_SetSeqName       (msa, idx, tok, ntok)) != eslOK) goto ERROR;

--- a/miniapps/esl-reformat.c
+++ b/miniapps/esl-reformat.c
@@ -357,7 +357,11 @@ main(int argc, char **argv)
          * It shoves all sequences into a single database, #1.
          */
         date = time(NULL);
+#ifdef __MINGW32__
+        ctime_s(timestamp, sizeof(timestamp), &date);
+#else
         ctime_r(&date, timestamp);
+#endif
         fprintf(mapfp, "%d\n", idx);
         fprintf(ofp, "#%" PRId64 " %d %d %d %d %s", res_cnt, idx, 1, idx, idx, timestamp);
 


### PR DESCRIPTION
Hi!

With the following preprocessor directives, I am successful in compiling `easel` on Windows with MinGW, allowing for an (almost) native compilation of Easel on Windows.  Contrary to Cygwin, MinGW lets you compile an binary that works even in the plain Windows environment, so this should be a first step towards getting Easel and HMMER on Windows.

Changes are:
- Use `_putenv_s` instead of `setenv` when `setenv` is not available (it's only used in the tests I think).
- Check for a working `mmap` function before compiling `mmap` support in `esl_buffer.c`, instead of relying on `_POSIX_VERSION` (which is defined for MinGW while MinGW has no `mmap` support).
- Check for the `fstat` function before calling `fstat` in `esl_buffer_OpenFile` (once again, instead of relying on `_POSIX_VERSION`).
- Check if the `stat` struct has an `st_blksize` (which is not the case on Windows) before using it to get the block size in `esl_buffer_OpenFile`
- Use `GetTempPathA` to find the temporary folder in `esl_tmpfile` (it internally uses the environment variables, but this function provides consistent behaviour on Windows)
- Use `ctime_s` instead of `ctime_r` when compiling for MinGW, since `ctime_r` is not available on Windows while `ctime_s` is.

Although it builds, not all tests pass at the moment, most likely due to remaining compatibility issues. The following keep failing:
- `buffer-utest`
- `getopts-utest`
- `sqio-utest`
- `ssi-utest`
- `degen-residues`

All the `miniapps` are marked as crashing as well, but I can make them run fine, even in a `cmd.exe` shell, so I think it's more likely a test driver issue than an actual crash, although there may be some edge cases:
![image](https://user-images.githubusercontent.com/8660647/146479060-28d1e9cd-536c-4a46-acc2-28f7fd7b38d0.png)


