### PR TITLE
Reduce thread contention, allowing 8-12% faster jackhmmer

### DIFF
--- a/esl_workqueue.c
+++ b/esl_workqueue.c
@@ -515,7 +515,7 @@ int esl_workqueue_ReaderUpdate(ESL_WORK_QUEUE *queue, void *in, void **out)
 
       if (queue->pendingWorkers != 0)
 	{
-	  if (pthread_cond_broadcast (&queue->workerQueueCond) != 0) ESL_EXCEPTION(eslESYS, "broadcast failed");
+	  if (pthread_cond_signal (&queue->workerQueueCond) != 0) ESL_EXCEPTION(eslESYS, "pthread_cond_signal failed");
 	}
     }
 


### PR DESCRIPTION
## Summary of effects
- jackhmmer is 8-12% faster (when allowing more threads) than previous 8 threads. 
  - E.g. saves >1 minute for a uniref50 jackhmmer run on a short query protein and can save 5 minutes on a jackhmmer against uniprotkb
- even without setting threads higher than 8, jackhmmer appears to be about 3% faster on large runs
- jackhmmer run with >8 threads no longer sees performance degradation
- system-time substantially decreases when using >8 threads

## Description of change
`pthread_cond_broadcast (&queue->workerQueueCond)`:  This condition variable signals workers that new work is available.

Unnecessary Broadcasts: The `pthread_cond_broadcast` wakes up all waiting workers, even if there's only one new work item. This can cause unnecessary context switches and contention as workers compete for the lock. A `pthread_cond_signal` is more efficient, waking up just one worker. In more extreme cases, this can cause stampeding herd phenomena.

## Performance measurements
On a 128 core machine.

### jackhmmer against swissprot
(500k sequences)

```
hyperfine -r 10 --warmup 1 "jackhmmer --cpu <<N>> /tmp/hemoglobin.fasta /dev/shm/uniprot_swissprot.fasta"
```

|N cores|walltime before|walltime after|
|:----:|:----:|:----:|
|1|10.871 s ±  0.248 s|11.052 s ±  0.169 s|
|2|7.212 s ±  0.297 s|7.286 s ±  0.308 s|
|4|6.787 s ±  0.145 s|6.988 s ±  0.226 s|
|8|6.821 s ±  0.110 s|6.771 s ±  0.133 s|
|16|7.212 s ±  0.297 s|7.286 s ±  0.308 s|
|32|6.635 s ±  0.081 s|6.253 s ±  0.069 s|
|64|6.971 s ±  0.117 s|6.196 s ±  0.078 s|
|128|7.878 s ±  0.108 s|6.332 s ±  0.191 s|

### jackhmmer against UniRef50
(65M sequences)

Used 3 reruns, no warmup because it takes so long. Notably, if we compare a run of jackhmmer without the thread-contention change vs with at `--cpu=32` on UniRef, we see a huge spike in system time:
```
without: [Usertime : 1541.411 s, System time: 256.628 s]
with:    [User time: 1448.193 s, System time: 23.326 s]
```
|N cores|walltime before|walltime after|
|:----:|:----:|:----:|
|8 |606.021 s ±  9.104 s|588.184 s ± 15.256 s|
|32|608.369 s ±  ??? s|557.582 s ±  ??? s|
|128|715.781 s ±  5.827 s|536.481 s ±  0.169 s|

### jackhmmer against TrEMBL
(250M sequences)

Used a single run instead of rerunning because it takes thousands of seconds

|N cores |walltime before|walltime after|
|:----:|:----:|:----:|
|8|2692|TBD|
|128|TBD|2509 ±  ??? s|