### PR TITLE
Fix size_t formatting in ESL_ALLOC/ESL_RALLOC/ESL_REALLOC error messages

### DIFF
--- a/easel.h
+++ b/easel.h
@@ -185,7 +185,7 @@
     }\
     if ( ((p) = malloc(size)) == NULL)  { \
        status = eslEMEM;\
-       esl_exception(status, FALSE, __FILE__, __LINE__, "malloc of size %d failed", size); \
+       esl_exception(status, FALSE, __FILE__, __LINE__, "malloc of size %llu failed", (unsigned long long) size); \
        goto ERROR;\
      }} while (0)
 
@@ -195,7 +195,7 @@
      if ((tmp) != NULL) (p) = (tmp);\
      else {\
        status = eslEMEM;\
-       esl_exception(status, FALSE, __FILE__, __LINE__, "realloc for size %d failed", newsize);	\
+       esl_exception(status, FALSE, __FILE__, __LINE__, "realloc for size %llu failed", (unsigned long long) newsize); \
        goto ERROR;\
      }} while (0)
 
@@ -206,7 +206,7 @@
      if ((esltmpp) != NULL) (p) = (esltmpp);\
      else {\
        status = eslEMEM;\
-       esl_exception(status, FALSE, __FILE__, __LINE__, "realloc for size %d failed", newsize); \
+       esl_exception(status, FALSE, __FILE__, __LINE__, "realloc for size %llu failed", (unsigned long long) newsize); \
        goto ERROR;\
      }} while (0)
 /*::cexcerpt::alloc_macros::end::*/


### PR DESCRIPTION
## Summary
- `easel.h:188` (ESL_ALLOC), `easel.h:198` (ESL_RALLOC), and `easel.h:209` (ESL_REALLOC) all use `%d` to print the allocation size, which is a `size_t`.
- For allocations larger than 2 GB, `%d` truncates the value to a signed 32-bit int and displays a negative number, which is misleading when diagnosing realloc failures at scale.
- Replace with `%llu` and an `(unsigned long long)` cast, matching the convention used elsewhere in HMMER (e.g. `shard.c:719`, `cachedb_shard.c`).

## Why
The misleading message contributed real diagnostic confusion in a downstream investigation of large-scale HMM alignment. Realloc failures of multi-GB requests printed as e.g. `realloc for size -1535220784 failed`, which initially looked like an integer-overflow bug in the size computation. The size computation is actually correct (64-bit clean); only the error message was lying. The fix replaces the misleading display with the true size in bytes.

## Risk
Format-string change only. No behavioral, allocator, or ABI change. The macros are otherwise byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)